### PR TITLE
fix: exec cd before running tar -czf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Update Release version
         run: sed -i "s/##VERSION##/${{ steps.prep.outputs.version }}/g" .saucetpl/.sauce/config.yml
       - name: Archive template
-        run: tar --strip-components=1 -czf saucetpl.tar.gz .saucetpl
+        run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
GNU tar does not support `--strip-components=1` while compressing (only extracting).
`cd` is required as a workaround.