### PR TITLE
fix: Ensure testcafe exitCode is propagated up to saucectl

### DIFF
--- a/src/console-wrapper.js
+++ b/src/console-wrapper.js
@@ -20,8 +20,8 @@ const child_process = require('child_process');
     child.stdout.pipe(ws);
     child.stderr.pipe(ws);
 
-    child.on('exit', (exitCode) => ws.end(() => {
+    child.on('exit', (exitCode) => {
         fs.closeSync(fd);
         process.exit(exitCode);
-    }));
+    });
 })();


### PR DESCRIPTION
## Proposed changes

Restore expected `exitCode` to be non-zero when some tests are failing.
Relates: https://github.com/saucelabs/testrunner-toolkit/issues/63

![render1604429634191](https://user-images.githubusercontent.com/11074879/98028950-aa6c8900-1dc3-11eb-9bfa-67b3f16919ac.gif)


### Considerations

It's not optimum since `stream.Writable` is not cleanly closed before file being closed. As soon as operations are maid on stream either `ws.end()` or waiting for `stream.finished()`, `exitCode` resets to 0 and npm is not failing as expected.