### PR TITLE
Docker: Store job details url in file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ ARG BUILD_TAG
 ENV IMAGE_TAG=${BUILD_TAG}
 
 # Let saucectl know where to read job details url
-LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
+LABEL com.saucelabs.job-info=/tmp/output.json
 
 CMD ["./entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,7 @@ ENV IMAGE_NAME=saucelabs/stt-testcafe-node
 ARG BUILD_TAG
 ENV IMAGE_TAG=${BUILD_TAG}
 
+# Let saucectl know where to read job details url
+LABEL com.saucelabs.job-details-url=/tmp/output-job-details-url
+
 CMD ["./entry.sh"]

--- a/src/sauce-testreporter.js
+++ b/src/sauce-testreporter.js
@@ -255,5 +255,10 @@ exports.sauceReporter = async ({browserName, assets, results, startTime, endTime
       domain = `${region}.saucelabs.${tld}`;
   }
 
-  console.log(`\nOpen job details page: https://app.${domain}/tests/${sessionId}\n`);
+  const jobDetailsUrl = `https://app.${domain}/tests/${sessionId}`;
+  console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
+
+  // Store file containing job-details url.
+  // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
+  fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
 };

--- a/src/sauce-testreporter.js
+++ b/src/sauce-testreporter.js
@@ -259,6 +259,8 @@ exports.sauceReporter = async ({browserName, assets, results, startTime, endTime
   console.log(`\nOpen job details page: ${jobDetailsUrl}\n`);
 
   // Store file containing job-details url.
-  // Path is similar to com.saucelabs.job-details-url LABEL in Dockerfile.
-  fs.writeFileSync('/tmp/output-job-details-url', jobDetailsUrl);
+  // Path is similar to com.saucelabs.job-info LABEL in Dockerfile.
+  fs.writeFileSync('/tmp/output.json', JSON.stringify({
+    jobDetailsUrl
+  }));
 };


### PR DESCRIPTION
In docker mode, store job detail URL in a file to allow saucectl to retrieve it.