### PR TITLE
Fix the issue when uploading assets

### DIFF
--- a/src/sauce-testreporter.js
+++ b/src/sauce-testreporter.js
@@ -182,7 +182,7 @@ const createJobWorkaround = async (api, browserName, testName, tags, build, pass
   return sessionId || 0;
 };
 
-exports.sauceReporter = async ({browserName, assets, results, startTime, endTime}) => {
+exports.sauceReporter = async ({browserName, assets, assetsPath, results, startTime, endTime}) => {
 // SAUCE_JOB_NAME is only available for saucectl >= 0.16, hence the fallback
   const testName = process.env.SAUCE_JOB_NAME || `DevX TestCafe Test Run - ${(new Date()).getTime()}`;
 
@@ -217,9 +217,10 @@ exports.sauceReporter = async ({browserName, assets, results, startTime, endTime
   // create sauce asset
   console.log('Preparing assets');
   let [nativeLogJson, logJson] = await exports.createSauceJson(
-    path.join(assets, 'reports'),
-    path.join(assets, 'report.xml')
+    path.join(assetsPath, 'reports'),
+    path.join(assetsPath, 'report.xml')
   );
+
   let uploadAssets = [...assets, logJson, nativeLogJson];
   // updaload assets
   await Promise.all([


### PR DESCRIPTION
Fix the issue
```
Could not complete test. Reason 'The "path" argument must be of type string. Received an instance of Array'
```

Successful example: https://app.saucelabs.com/tests/6afac0bac5794410884772fa07971bdc