### PR TITLE
CI: support restarting pipeline with no side-effects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           fi
           echo ::set-output name=tag_name::${TAG_NAME}
 
+      - run: |
+          echo "[${{ steps.check.outputs.tag_name }}]"
+
       - uses: actions/checkout@v2
         if: ${{ steps.check.outputs.tag_name == '' }}
         with:
@@ -45,11 +48,13 @@ jobs:
           node-version: 14.x
 
       - name: Setup Git
+        if: ${{ steps.check.outputs.tag_name == '' }}
         run: |
           git config --global user.name "devx-sauce-bot"
           git config --global user.email "devx.bot@saucelabs.com"
 
       - name: Install dependencies
+        if: ${{ steps.check.outputs.tag_name == '' }}
         run: npm ci
 
       - name: generate (pre-)release draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check tag
-        id: check
+        id: prep
         run: |
           TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
@@ -32,33 +32,30 @@ jobs:
           fi
           echo ::set-output name=tag_name::${TAG_NAME}
 
-      - run: |
-          echo "[${{ steps.check.outputs.tag_name }}]"
-
       - uses: actions/checkout@v2
-        if: ${{ steps.check.outputs.tag_name == '' }}
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node version
         uses: actions/setup-node@v1
-        if: ${{ steps.check.outputs.tag_name == '' }}
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         with:
           node-version: 14.x
 
       - name: Setup Git
-        if: ${{ steps.check.outputs.tag_name == '' }}
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: |
           git config --global user.name "devx-sauce-bot"
           git config --global user.email "devx.bot@saucelabs.com"
 
       - name: Install dependencies
-        if: ${{ steps.check.outputs.tag_name == '' }}
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: npm ci
 
       - name: generate (pre-)release draft
-        if: ${{ steps.check.outputs.tag_name == '' }}
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -138,7 +135,7 @@ jobs:
           $selectedRelease = $null
           Foreach ($release in $jsonObj)
           {
-              if ( ! $release.body -contains "- jobId: ${{ github.run_id }}}\\n") {
+              if ( ! $release.body -contains "- jobId: ${{ github.run_id }}\\n") {
                   continue
               }
               if ( ! $release.draft ) {
@@ -152,35 +149,51 @@ jobs:
               exit 1
           }
 
+          $selectedAsset = $null
+          Foreach ($asset in $selectedRelease.assets) {
+            if ($asset.name -eq "sauce-testcafe-runner.zip") {
+              $selectedAsset = $asset
+            }
+          }
+
           $tagName = $selectedRelease.tag_name
           $releaseId = $selectedRelease.id
+          $assetId = $selectedAsset.id
           Write-Output "::set-output name=version::$tagName"
           Write-Output "::set-output name=release_id::$releaseId"
+          Write-Output "::set-output name=asset_id::$assetId"
 
-      - run: Write-Output "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: Write-Output "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v14.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
 
       - run: npm ci --production
+        if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Bundle Directory
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: bash ./scripts/bundle.sh
 
       - name: List bundle contents
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: ls -R bundle/
 
       - name: Archive bundle
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: azure/powershell@v1
         with:
           inlineScript: |
@@ -188,6 +201,7 @@ jobs:
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -216,41 +230,56 @@ jobs:
               echo "No draft version found"
               exit 1
           fi
+
+          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"sauce-testcafe-macos.zip\") | .id | select(. != null)")
+
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=release_id::${RELEASE_ID}
+          echo ::set-output name=asset_id::${ASSET_ID}
 
-      - run: echo "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v12.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
 
       - run: npm ci --production
+        if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - uses: FedericoCarboni/setup-ffmpeg@v1
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: setup-ffmpeg
         with:
           token: ${{ github.token }}
 
       - name: Bundle Directory
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: bash ./scripts/bundle.sh
 
       - name: List bundle contents
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: ls -R bundle/
 
       - name: Archive bundle
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: zip -r sauce-testcafe-macos.zip bundle/
 
       - name: Upload Release Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -279,30 +308,41 @@ jobs:
               echo "No draft version found"
               exit 1
           fi
+
+          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"saucetpl.tar.gz\") | .id | select(. != null)")
+
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=release_id::${RELEASE_ID}
+          echo ::set-output name=asset_id::${ASSET_ID}
 
-      - run: echo "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v14.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
           TESTCAFE_VERSION=`< package-lock.json  jq -r '.dependencies["testcafe"].version'`
           sed -i "s/##VERSION##/${TESTCAFE_VERSION}/g" .saucetpl/.sauce/config.yml
 
       - name: Archive template
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
 
       - name: Upload Template Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -315,7 +355,7 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [release-docker,  release-template-bundle, release-windows-bundle, release-macos-bundle]
+    needs: [release-docker, release-template-bundle, release-windows-bundle, release-macos-bundle]
     steps:
       - name: Find matching draft tag
         id: prep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
         run: |
           TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name | select (. != null)")
           IS_DRAFT=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft")
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft | select (. != null)")
 
           if [ -n "${TAG_NAME}" ] && [ "${IS_DRAFT}" == "false" ];then
               echo "A release has already been published for this run_id (${{ github.run_id }} / ${TAG_NAME})."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,23 +104,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # - name: Build and push
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     push: true
-      #     context: .
-      #     file: ./Dockerfile
-      #     tags: |
-      #       saucelabs/stt-testcafe-node:latest
-      #       saucelabs/stt-testcafe-node:${{ steps.prep.outputs.version }}
-      #     build-args: |
-      #       BUILD_TAG=${{ steps.prep.outputs.version }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          tags: |
+            saucelabs/stt-testcafe-node:latest
+            saucelabs/stt-testcafe-node:${{ steps.prep.outputs.version }}
+          build-args: |
+            BUILD_TAG=${{ steps.prep.outputs.version }}
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,23 +102,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: .
-          file: ./Dockerfile
-          tags: |
-            saucelabs/stt-testcafe-node:latest
-            saucelabs/stt-testcafe-node:${{ steps.prep.outputs.version }}
-          build-args: |
-            BUILD_TAG=${{ steps.prep.outputs.version }}
+      # - name: Build and push
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     context: .
+      #     file: ./Dockerfile
+      #     tags: |
+      #       saucelabs/stt-testcafe-node:latest
+      #       saucelabs/stt-testcafe-node:${{ steps.prep.outputs.version }}
+      #     build-args: |
+      #       BUILD_TAG=${{ steps.prep.outputs.version }}
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,31 @@ jobs:
   create-release-draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Check tag
+        id: check
+        run: |
+          TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
+          IS_DRAFT=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft")
+
+          if [ -n "${TAG_NAME}" ] && [ "${IS_DRAFT}" == "false" ];then
+              echo "A release has already been published for this run_id (${{ github.run_id }} / ${TAG_NAME})."
+              exit 1
+          fi
+          echo ::set-output name=tag_name::${TAG_NAME}
+
       - uses: actions/checkout@v2
+        if: ${{ steps.check.outputs.tag_name == '' }}
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node version
         uses: actions/setup-node@v1
+        if: ${{ steps.check.outputs.tag_name == '' }}
         with:
           node-version: 14.x
 
@@ -35,6 +53,7 @@ jobs:
         run: npm ci
 
       - name: generate (pre-)release draft
+        if: ${{ steps.check.outputs.tag_name == '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
- Check for existing tag/release associated with current pipeline
- Avoid rebuilding templates/bundles
- Generate error if already publish

FYI: Checks failing because of cross-repo PR.