### PR TITLE
Update firefox to 86 and chrome to 89

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM saucelabs/testrunner-image:v0.1.1
+FROM saucelabs/testrunner-image:v0.2.0
 
 WORKDIR /home/seluser
 


### PR DESCRIPTION
Update the base image to `v0.2.0`, which contains the updated browsers. See https://github.com/saucelabs/testrunner-image/releases/tag/v0.2.0
This addresses our current issue with firefox + testcafe inside docker, because firefox 74 does not run with testcafe.