### PR TITLE
Default template to use mac

### DIFF
--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -18,7 +18,7 @@ suites:
     screenshots:
       takeOnFails: true
       fullPage: true
-    platformName: "Windows 10" # or "macOS 11.00"
+    platformName: "macOS 11.00" # or "Windows 10"
     env:
       hello: world
     speed: 1


### PR DESCRIPTION
Default template to use mac, since windows 10 is not yet available for testcafe `1.11.0`, which causes `saucectl new` + `saucectl run` to fail.