### PR TITLE
iOS support

### DIFF
--- a/bin/cypress
+++ b/bin/cypress
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-const { testCafeRunner } = require('../src/console-wrapper');
-
-(async () => await testCafeRunner())();

--- a/package-lock.json
+++ b/package-lock.json
@@ -18264,9 +18264,9 @@
       }
     },
     "testcafe-browser-provider-ios": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.1.0.tgz",
-      "integrity": "sha512-xuyItD9d7qepr8Z3LgSnfMXqZbIm5bQu6YDpNZaqjMYzdTHHW3d3T2rKsa4DI+VgHPQoDlMdsnXBcMEnlruWxg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.1.1.tgz",
+      "integrity": "sha512-L/MtLxdVCZ7uOylTeWzZ/gRBAMPo+2bnPAYmisF+k7mVzaCUEe+itZoYZj4lvdXuvB4H1QJlZuaTgbonzJcUSw==",
       "requires": {
         "babel-runtime": "^6.11.6",
         "desired-capabilities": "^0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6561,14 +6561,6 @@
       "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk=",
       "dev": true
     },
-    "desired-capabilities": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/desired-capabilities/-/desired-capabilities-0.1.0.tgz",
-      "integrity": "sha1-84YNEu3g2sgZpHzJWaaMULqbqD4=",
-      "requires": {
-        "extend": "^3.0.0"
-      }
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -7514,7 +7506,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -18264,12 +18257,11 @@
       }
     },
     "testcafe-browser-provider-ios": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.1.1.tgz",
-      "integrity": "sha512-L/MtLxdVCZ7uOylTeWzZ/gRBAMPo+2bnPAYmisF+k7mVzaCUEe+itZoYZj4lvdXuvB4H1QJlZuaTgbonzJcUSw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.3.0.tgz",
+      "integrity": "sha512-AXPznmK6/fhEIcVDAf2MSJG7WyTGNG7XAX+SgKt3ylpz3rjN6NuLsszs1x5x4zRYp/1zrgYoZX4fem+YML2xGQ==",
       "requires": {
-        "babel-runtime": "^6.11.6",
-        "desired-capabilities": "^0.1.0"
+        "babel-runtime": "^6.11.6"
       }
     },
     "testcafe-browser-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4995,6 +4995,22 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -6066,6 +6082,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+    },
     "core-js-compat": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.0.tgz",
@@ -6539,6 +6560,14 @@
       "resolved": "http://artifactory.inf.las1.saucelabs.net:80/artifactory/api/npm/all-npm/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk=",
       "dev": true
+    },
+    "desired-capabilities": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/desired-capabilities/-/desired-capabilities-0.1.0.tgz",
+      "integrity": "sha1-84YNEu3g2sgZpHzJWaaMULqbqD4=",
+      "requires": {
+        "extend": "^3.0.0"
+      }
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7485,8 +7514,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -18233,6 +18261,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "testcafe-browser-provider-ios": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.1.0.tgz",
+      "integrity": "sha512-xuyItD9d7qepr8Z3LgSnfMXqZbIm5bQu6YDpNZaqjMYzdTHHW3d3T2rKsa4DI+VgHPQoDlMdsnXBcMEnlruWxg==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "desired-capabilities": "^0.1.0"
       }
     },
     "testcafe-browser-tools": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sauce-testrunner-utils": "^0.3.0",
     "saucelabs": "^4.6.5",
     "testcafe": "1.11.0",
-    "testcafe-browser-provider-ios": "^0.1.0",
+    "testcafe-browser-provider-ios": "^0.1.1",
     "typescript": "^3.9.7",
     "xml2js": "^0.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sauce-testrunner-utils": "^0.3.0",
     "saucelabs": "^4.6.5",
     "testcafe": "1.11.0",
-    "testcafe-browser-provider-ios": "^0.1.1",
+    "testcafe-browser-provider-ios": "^0.3.0",
     "typescript": "^3.9.7",
     "xml2js": "^0.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sauce-testrunner-utils": "^0.3.0",
     "saucelabs": "^4.6.5",
     "testcafe": "1.11.0",
+    "testcafe-browser-provider-ios": "^0.1.0",
     "typescript": "^3.9.7",
     "xml2js": "^0.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sauce-testrunner-utils": "^0.3.0",
     "saucelabs": "^4.6.5",
     "testcafe": "1.11.0",
-    "testcafe-browser-provider-ios": "^0.3.0",
+    "testcafe-browser-provider-ios": "0.3.0",
     "typescript": "^3.9.7",
     "xml2js": "^0.4.23"
   },

--- a/src/console-wrapper.js
+++ b/src/console-wrapper.js
@@ -51,8 +51,8 @@ if (require.main === module) {
       })
       // eslint-disable-next-line promise/prefer-await-to-callbacks
       .catch((err) => {
-        console.log(err);
-        process.exit(1);
+        console.error(err);
+        process.exit(err);
       });
 }
 


### PR DESCRIPTION
* Adds [testcafe-browser-provider-ios](https://github.com/saucelabs/testcafe-browser-provider-ios) as a dependency which is a provider that uses `idb_companion` to launch and shutdown iOS Simulators
* The ios provider exits with specific statuses (e.g. `65` if the simulator boot command times out), so make sure the runner propagates the status that testcafe exited with.

#### Usage

This obviously only works on a mac:
```
npx testcafe "ios:iPad Pro (9.7-inch):iOS 13.3" ./tests/fixtures/devxpress-test/tests/devxpress.test.js
```

Where the "browser" provided here is prefixed with `ios` to namespace the plugin. Then the device is defined as `deviceName:iOS version`.

You can list available simulators like this:
```
$ npx testcafe --list-browsers ios
"ios:iPhone 11:iOS 13.3"
"ios:iPad Pro (9.7-inch):iOS 13.3"
"ios:iPhone X - 13.2:iOS 13.2"
"ios:iPhone 11:iOS 13.0"
"ios:iPhone 5s:iOS 12.2"
```

To use with the runner itself, you have to define the `SAUCE_BROWSER_PATH` environment variable:
```
$ export SAUCE_BROWSER_PATH="ios:iPhone 11:iOS 13.3"
$ export SAUCE_VM=truth
$ node . --runCfgPath ./tests/fixtures/sauceswag-ok/sauce-runner.json --suiteName "saucy test" 
```