### PR TITLE
Bump ios provider to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18367,9 +18367,9 @@
       }
     },
     "testcafe-browser-provider-ios": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.4.0.tgz",
-      "integrity": "sha512-Dn7MOnvIqzESNbOXnGJhcQjH8ljNU2WGEXiPf3LAJAo6yo1ezSaAWBEODqYdRYi/FxBKutdzMOPzHPPCwJ6c+w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-ios/-/testcafe-browser-provider-ios-0.5.0.tgz",
+      "integrity": "sha512-i95vuIRGXfu2JfGkiCJngiJ74ejSsbg0Y9yRMXMXbKkvod8qvi2WDMRfoqf1wdD6tKsAhg7qIprDJ3Q/v1HzOw==",
       "requires": {
         "babel-runtime": "^6.11.6"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sauce-testrunner-utils": "^0.3.0",
     "saucelabs": "4.7.5",
     "testcafe": "1.14.0",
-    "testcafe-browser-provider-ios": "0.4.0",
+    "testcafe-browser-provider-ios": "0.5.0",
     "typescript": "^3.9.7",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
Includes an option to skip sim shutdown at end of test