### PR TITLE
Set environment variables before invoking TestCafe

### DIFF
--- a/src/testcafe-runner.js
+++ b/src/testcafe-runner.js
@@ -14,6 +14,11 @@ async function prepareConfiguration (runCfgPath, suiteName) {
     const suite = getSuite(runCfg, suiteName);
     const metadata = runCfg.sauce.metadata || {};
 
+    // Set env vars
+    for (const key in suite.env) {
+      process.env[key] = suite.env[key];
+    }
+
     // Install NPM dependencies
     let metrics = [];
     let npmMetrics = await prepareNpmEnv(runCfg);

--- a/tests/unit/src/testcafe-runner.spec.js
+++ b/tests/unit/src/testcafe-runner.spec.js
@@ -16,6 +16,7 @@ const baseSuite = {
   name: 'fake-suite-name',
   browserName: 'chrome',
   src: ['tests/*.*'],
+  env: {'my-key': 'my-val'},
   selectorTimeout: 1234,
   skipJsErrors: true,
   quarantineMode: true,
@@ -98,6 +99,7 @@ describe('.run', function () {
     };
     expect(results).toMatchSnapshot();
     expect(sauceReporter.mock.calls).toMatchSnapshot();
+    expect(process.env['my-key']).toBe('my-val');
   });
   it('calls TestCafe method with a kitchen sink runCfg (Sauce VM mode)', async function () {
     process.env = {


### PR DESCRIPTION
Set environments variables from configuration before invoking TestCafe.
Run as a part of `prepareConfiguration` before running npm install.

Relates to https://github.com/saucelabs/saucectl/issues/298