### PR TITLE
Bump runner-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17071,9 +17071,9 @@
       }
     },
     "sauce-testrunner-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-0.4.2.tgz",
-      "integrity": "sha512-M5zRssQJED0mJ2hR7cDUCdQ4ER4K0TSFz8OJHgQIoBf96aJtjVcQ2zr8saXDBxnflMHuswmojMaKLAFlLIPt3A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-0.4.4.tgz",
+      "integrity": "sha512-o1UGLk/ytIzHuidssx4ZvurP8N5xUbTm4eVa5eN2uK3e6YpA5JZhyJkyA5YPcKg9H2wcDfuheG9aPf/az76u1A==",
       "requires": {
         "lodash": "^4.17.20",
         "npm": "^6.14.9"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.1.6",
     "js-yaml": "^3.14.0",
     "mocha-junit-reporter": "^2.0.0",
-    "sauce-testrunner-utils": "0.4.2",
+    "sauce-testrunner-utils": "0.4.4",
     "saucelabs": "4.7.5",
     "testcafe": "1.14.0",
     "testcafe-browser-provider-ios": "0.5.0",


### PR DESCRIPTION
0.4.4 has a fix for how `npm install` behaves if there is a `package-lock.json` in the cwd.