### PR TITLE
[DEVX-1146] Add browserArgs for testcafe runner

### DIFF
--- a/src/testcafe-runner.js
+++ b/src/testcafe-runner.js
@@ -57,6 +57,11 @@ async function runTestCafe ({projectPath, assetsPath, suite, metrics, timeoutSec
       throw new Error(`Unsupported browser: ${testCafeBrowserName}.`);
     }
 
+    if (suite.browserArgs) {
+      const browserArgs = suite.browserArgs.join(' ');
+      testCafeBrowserName = testCafeBrowserName + ' ' + browserArgs;
+    }
+
     // Get the 'src' array and translate it to fully qualified URLs that are part of project path
     let src = Array.isArray(suite.src) ? suite.src : [suite.src];
     src = src.map((srcPath) => path.join(projectPath, srcPath));


### PR DESCRIPTION
I set browserArgs as `--start-fullscreen --start-in-incognito`.
w/ args: https://app.saucelabs.com/tests/6608588934984d59aa18bed4272603a9
w/o args: https://app.saucelabs.com/tests/b46c5a06fc0e4d559503fb688e1c8a30