### PR TITLE
[DEVX-1160] Bump testcafe version to v1.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "mocha-junit-reporter": "^2.0.0",
         "sauce-testrunner-utils": "0.4.5",
         "saucelabs": "4.7.5",
-        "testcafe": "1.15.0",
+        "testcafe": "1.15.3",
         "testcafe-browser-provider-ios": "0.5.0",
         "typescript": "^3.9.7",
         "xml-js": "1.6.11",
@@ -4726,9 +4726,9 @@
       }
     },
     "node_modules/acorn-hammerhead": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.4.0.tgz",
-      "integrity": "sha512-zMjPa6kNgMB0zclCZI41sPofSeeHMF9Q6e3ALRsowmmNqoiz1qiJI9oemt9GfZ5e5EmQpElvePT3AVcLU3AzHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.5.0.tgz",
+      "integrity": "sha512-TI9TFfJBfduhcM2GggayNhdYvdJ3UgS/Bu3sB7FB2AUmNCmCJ+TSOT6GXu+bodG5/xL74D5zE4XRaqyjgjsYVQ==",
       "dependencies": {
         "@types/estree": "0.0.46"
       }
@@ -8130,6 +8130,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/esotope-hammerhead": {
       "version": "0.6.1",
@@ -16267,6 +16275,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -16281,16 +16290,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -16304,6 +16316,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -16319,6 +16332,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21380,9 +21394,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.0.tgz",
-      "integrity": "sha512-wzuNLXW40UuzlTnI0/m8IFEKuwMM1Vt1IE5jWC8fAbJ6PPjFyM5HyC6Rn8gA0dwe4Bn1IhoybaQezS8tpIkcdg==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.3.tgz",
+      "integrity": "sha512-HiHDLSew6y0+60tz4lssh5BqY9Jw0kZlk85GWYS0V9Tla+QL/kT+gSGCxUoBwfCt+ZwjfU1R6qs9qnGbkflvjw==",
       "dependencies": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -21411,7 +21425,7 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^2.8.1",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
@@ -21421,6 +21435,7 @@
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
+        "esm": "^3.2.25",
         "execa": "^4.0.3",
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
@@ -21457,8 +21472,8 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.15",
-        "testcafe-hammerhead": "24.3.1",
+        "testcafe-browser-tools": "2.0.16",
+        "testcafe-hammerhead": "24.5.1",
         "testcafe-legacy-api": "5.0.2",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
@@ -21487,11 +21502,12 @@
       }
     },
     "node_modules/testcafe-browser-tools": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.15.tgz",
-      "integrity": "sha512-bzkh5B1+Ws/I3YZL+9M4TSUq3aAewjvF2oue2l7T7eROIvqwPDE22ZFfPuLew6VIZcotCFZj432s1EgJDFyH7g==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.16.tgz",
+      "integrity": "sha512-JljbS0FboABksIMEH1L7P4ZdI82AQ8saWb/7WsxkDCOtDuHID5ZSEb/w9tqLN1+4BQaCgS5veN3lWUnfb0saEA==",
       "dependencies": {
         "array-find": "^1.0.0",
+        "debug": "^4.3.1",
         "dedent": "^0.7.0",
         "del": "^5.1.0",
         "execa": "^3.3.0",
@@ -21517,6 +21533,22 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/testcafe-browser-tools/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/testcafe-browser-tools/node_modules/dedent": {
@@ -21616,12 +21648,20 @@
       }
     },
     "node_modules/testcafe-browser-tools/node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/testcafe-browser-tools/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/testcafe-browser-tools/node_modules/nanoid": {
       "version": "2.1.11",
@@ -21648,14 +21688,17 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.3.1.tgz",
-      "integrity": "sha512-c6eoxfEeLN47/2ToVKP7n8jupUtZijMjIBhhAiVW4HqZ2v+9GNn6wH8GKyWbsmov0hacaYMEvp4mwehJstKjxg==",
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.1.tgz",
+      "integrity": "sha512-upLFJbEH3unQ8dq65AZdevYgWaJtWiALKW5YO5uWbx7lLvMMeQbyA7gnwrlGbIaepUdi+PlW4dORjncrU+lY/Q==",
       "dependencies": {
-        "acorn-hammerhead": "0.4.0",
+        "acorn-hammerhead": "0.5.0",
         "asar": "^2.0.1",
         "bowser": "1.6.0",
         "brotli": "^1.3.1",
@@ -21822,6 +21865,14 @@
       "version": "12.20.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
       "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
+    },
+    "node_modules/testcafe/node_modules/commander": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/testcafe/node_modules/debug": {
       "version": "4.3.1",
@@ -27514,9 +27565,9 @@
       }
     },
     "acorn-hammerhead": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.4.0.tgz",
-      "integrity": "sha512-zMjPa6kNgMB0zclCZI41sPofSeeHMF9Q6e3ALRsowmmNqoiz1qiJI9oemt9GfZ5e5EmQpElvePT3AVcLU3AzHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.5.0.tgz",
+      "integrity": "sha512-TI9TFfJBfduhcM2GggayNhdYvdJ3UgS/Bu3sB7FB2AUmNCmCJ+TSOT6GXu+bodG5/xL74D5zE4XRaqyjgjsYVQ==",
       "requires": {
         "@types/estree": "0.0.46"
       }
@@ -30315,6 +30366,11 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esotope-hammerhead": {
       "version": "0.6.1",
@@ -36615,7 +36671,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -36627,15 +36684,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -36646,7 +36706,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -36658,7 +36719,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -40665,9 +40727,9 @@
       }
     },
     "testcafe": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.0.tgz",
-      "integrity": "sha512-wzuNLXW40UuzlTnI0/m8IFEKuwMM1Vt1IE5jWC8fAbJ6PPjFyM5HyC6Rn8gA0dwe4Bn1IhoybaQezS8tpIkcdg==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.15.3.tgz",
+      "integrity": "sha512-HiHDLSew6y0+60tz4lssh5BqY9Jw0kZlk85GWYS0V9Tla+QL/kT+gSGCxUoBwfCt+ZwjfU1R6qs9qnGbkflvjw==",
       "requires": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -40696,7 +40758,7 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^2.8.1",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
@@ -40706,6 +40768,7 @@
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
+        "esm": "^3.2.25",
         "execa": "^4.0.3",
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
@@ -40742,8 +40805,8 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.15",
-        "testcafe-hammerhead": "24.3.1",
+        "testcafe-browser-tools": "2.0.16",
+        "testcafe-hammerhead": "24.5.1",
         "testcafe-legacy-api": "5.0.2",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
@@ -40761,6 +40824,11 @@
           "version": "12.20.13",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
           "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
+        },
+        "commander": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+          "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
         },
         "debug": {
           "version": "4.3.1",
@@ -40791,11 +40859,12 @@
       }
     },
     "testcafe-browser-tools": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.15.tgz",
-      "integrity": "sha512-bzkh5B1+Ws/I3YZL+9M4TSUq3aAewjvF2oue2l7T7eROIvqwPDE22ZFfPuLew6VIZcotCFZj432s1EgJDFyH7g==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.16.tgz",
+      "integrity": "sha512-JljbS0FboABksIMEH1L7P4ZdI82AQ8saWb/7WsxkDCOtDuHID5ZSEb/w9tqLN1+4BQaCgS5veN3lWUnfb0saEA==",
       "requires": {
         "array-find": "^1.0.0",
+        "debug": "^4.3.1",
         "dedent": "^0.7.0",
         "del": "^5.1.0",
         "execa": "^3.3.0",
@@ -40816,6 +40885,14 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "dedent": {
           "version": "0.7.0",
@@ -40893,9 +40970,14 @@
           "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "nanoid": {
           "version": "2.1.11",
@@ -40921,11 +41003,11 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.3.1.tgz",
-      "integrity": "sha512-c6eoxfEeLN47/2ToVKP7n8jupUtZijMjIBhhAiVW4HqZ2v+9GNn6wH8GKyWbsmov0hacaYMEvp4mwehJstKjxg==",
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.1.tgz",
+      "integrity": "sha512-upLFJbEH3unQ8dq65AZdevYgWaJtWiALKW5YO5uWbx7lLvMMeQbyA7gnwrlGbIaepUdi+PlW4dORjncrU+lY/Q==",
       "requires": {
-        "acorn-hammerhead": "0.4.0",
+        "acorn-hammerhead": "0.5.0",
         "asar": "^2.0.1",
         "bowser": "1.6.0",
         "brotli": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "sauce-testrunner-utils": "0.4.5",
     "saucelabs": "4.7.5",
-    "testcafe": "1.15.0",
+    "testcafe": "1.15.3",
     "testcafe-browser-provider-ios": "0.5.0",
     "typescript": "^3.9.7",
     "xml-js": "1.6.11",


### PR DESCRIPTION
Verified with tests in example.

passed=true suite="iOS Test" url=https://app.saucelabs.com/tests/03769145feb64747aeaf7d58ce399117
passed=true suite="iOS Test" url=https://app.saucelabs.com/tests/2cca1261d8b44d1981f4bd739862ba70
passed=true suite="Firefox in sauce" url=https://app.saucelabs.com/tests/9a59d34db60d45f6a43b2fc5d9ca5d82
passed=true suite="Chrome using global mode setting" url=https://app.saucelabs.com/tests/d78bd8c2dec6410cba4e599de5f192af
passed=true suite="Firefox in docker" url=https://app.saucelabs.com/tests/cda3b53e906b4ada9f4166640aa8e185