### PR TITLE
[DEVX-1637] Standardize release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,18 +206,28 @@ jobs:
         uses: azure/powershell@v1
         with:
           inlineScript: |
-            Compress-Archive bundle/ sauce-testcafe-runner.zip
+            Compress-Archive bundle/ sauce-testcafe-runner-win-amd64.zip
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-testcafe-runner-win-amd64.zip
+          asset_path: ./sauce-testcafe-runner-win-amd64.zip
+          asset_name: sauce-testcafe-runner-win-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-testcafe-runner.zip
-          asset_path: ./sauce-testcafe-runner.zip
+          asset_path: ./sauce-testcafe-runner-win-amd64.zip
           asset_name: sauce-testcafe-runner.zip
           asset_content_type: application/zip
 
@@ -285,17 +295,27 @@ jobs:
 
       - name: Archive bundle
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        run: zip -r sauce-testcafe-macos.zip bundle/
+        run: zip -r sauce-testcafe-macos-amd64.zip bundle/
 
       - name: Upload Release Asset
         if: ${{ steps.prep.outputs.asset_id == '' }}
-        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-testcafe-macos-amd64.zip
+          asset_path: ./sauce-testcafe-macos-amd64.zip
+          asset_name: sauce-testcafe-macos-amd64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset Legacy
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=sauce-testcafe-macos.zip
-          asset_path: ./sauce-testcafe-macos.zip
+          asset_path: ./sauce-testcafe-macos-amd64.zip
           asset_name: sauce-testcafe-macos.zip
           asset_content_type: application/zip
 


### PR DESCRIPTION
Standardize release assets according to the new format: `{framework}-{os}-{arch}.zip`

This change does not replace legacy assets. At least not until all images are built using the new assets.
