### PR TITLE
Pre install runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "glob": "^7.1.6",
-        "js-yaml": "^3.14.0",
         "mocha-junit-reporter": "^2.0.0",
-        "npm": "^7.24.2",
         "sauce-testrunner-utils": "0.6.1",
         "saucelabs": "4.7.5",
         "testcafe": "1.19.0",
         "testcafe-browser-provider-ios": "0.5.0",
         "testcafe-reporter-sauce-json": "0.5.0",
         "typescript": "^3.9.7",
-        "xml-js": "1.6.11",
-        "xml2js": "^0.4.23"
+        "xml-js": "1.6.11"
       },
       "bin": {
         "sauce-testcafe-runner": "bin/testcafe"
@@ -39,8 +35,7 @@
         "jest": "^26.4.2",
         "mocha": "^8.1.3",
         "release-it": "^14.4.1",
-        "saucectl": "0.97.0",
-        "typescript": "^3.9.7"
+        "saucectl": "0.97.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12458,162 +12453,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
-      "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/ci-detect",
-        "@npmcli/config",
-        "@npmcli/map-workspaces",
-        "@npmcli/package-json",
-        "@npmcli/run-script",
-        "abbrev",
-        "ansicolors",
-        "ansistyles",
-        "archy",
-        "cacache",
-        "chalk",
-        "chownr",
-        "cli-columns",
-        "cli-table3",
-        "columnify",
-        "fastest-levenshtein",
-        "glob",
-        "graceful-fs",
-        "hosted-git-info",
-        "ini",
-        "init-package-json",
-        "is-cidr",
-        "json-parse-even-better-errors",
-        "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
-        "libnpmhook",
-        "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
-        "libnpmsearch",
-        "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minipass",
-        "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
-        "ms",
-        "node-gyp",
-        "nopt",
-        "npm-audit-report",
-        "npm-install-checks",
-        "npm-package-arg",
-        "npm-pick-manifest",
-        "npm-profile",
-        "npm-registry-fetch",
-        "npm-user-validate",
-        "npmlog",
-        "opener",
-        "pacote",
-        "parse-conflict-json",
-        "qrcode-terminal",
-        "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
-        "semver",
-        "ssri",
-        "tar",
-        "text-table",
-        "tiny-relative-date",
-        "treeverse",
-        "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
-      ],
-      "dependencies": {
-        "@isaacs/string-locale-compare": "*",
-        "@npmcli/arborist": "*",
-        "@npmcli/ci-detect": "*",
-        "@npmcli/config": "*",
-        "@npmcli/map-workspaces": "*",
-        "@npmcli/package-json": "*",
-        "@npmcli/run-script": "*",
-        "abbrev": "*",
-        "ansicolors": "*",
-        "ansistyles": "*",
-        "archy": "*",
-        "cacache": "*",
-        "chalk": "*",
-        "chownr": "*",
-        "cli-columns": "*",
-        "cli-table3": "*",
-        "columnify": "*",
-        "fastest-levenshtein": "*",
-        "glob": "*",
-        "graceful-fs": "*",
-        "hosted-git-info": "*",
-        "ini": "*",
-        "init-package-json": "*",
-        "is-cidr": "*",
-        "json-parse-even-better-errors": "*",
-        "libnpmaccess": "*",
-        "libnpmdiff": "*",
-        "libnpmexec": "*",
-        "libnpmfund": "*",
-        "libnpmhook": "*",
-        "libnpmorg": "*",
-        "libnpmpack": "*",
-        "libnpmpublish": "*",
-        "libnpmsearch": "*",
-        "libnpmteam": "*",
-        "libnpmversion": "*",
-        "make-fetch-happen": "*",
-        "minipass": "*",
-        "minipass-pipeline": "*",
-        "mkdirp": "*",
-        "mkdirp-infer-owner": "*",
-        "ms": "*",
-        "node-gyp": "*",
-        "nopt": "*",
-        "npm-audit-report": "*",
-        "npm-install-checks": "*",
-        "npm-package-arg": "*",
-        "npm-pick-manifest": "*",
-        "npm-profile": "*",
-        "npm-registry-fetch": "*",
-        "npm-user-validate": "*",
-        "npmlog": "*",
-        "opener": "*",
-        "pacote": "*",
-        "parse-conflict-json": "*",
-        "qrcode-terminal": "*",
-        "read": "*",
-        "read-package-json": "*",
-        "read-package-json-fast": "*",
-        "readdir-scoped-modules": "*",
-        "rimraf": "*",
-        "semver": "*",
-        "ssri": "*",
-        "tar": "*",
-        "text-table": "*",
-        "tiny-relative-date": "*",
-        "treeverse": "*",
-        "validate-npm-package-name": "*",
-        "which": "*",
-        "write-file-atomic": "*"
-      },
-      "bin": {
-        "npm": "bin/npm-cli.js",
-        "npx": "bin/npx-cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
@@ -12644,2508 +12483,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.9.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.0.1",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^1.0.2",
-        "@npmcli/metavuln-calculator": "^1.1.0",
-        "@npmcli/move-file": "^1.1.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^1.0.1",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.2",
-        "bin-links": "^2.2.1",
-        "cacache": "^15.0.3",
-        "common-ancestor-path": "^1.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "json-stringify-nice": "^1.1.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.0",
-        "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
-        "proc-log": "^1.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "treeverse": "^1.0.4",
-        "walk-up-path": "^1.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "1.3.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.3.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ini": "^2.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
-        "semver": "^7.3.4",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^1.3.2",
-        "lru-cache": "^6.0.0",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^6.1.1",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "installed-package-contents": "index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^7.1.6",
-        "minimatch": "^3.0.4",
-        "read-package-json-fast": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^15.0.5",
-        "pacote": "^11.1.11",
-        "semver": "^7.3.2"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "1.3.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "infer-owner": "^1.0.4"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^1.0.2",
-        "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^7.1.0",
-        "read-package-json-fast": "^2.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/agent-base": {
-      "version": "6.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ajv": {
-      "version": "6.12.6",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/ansicolors": {
-      "version": "0.3.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/ansistyles": {
-      "version": "0.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/archy": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/asn1": {
-      "version": "0.2.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/asynckit": {
-      "version": "0.4.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/aws4": {
-      "version": "1.11.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/npm/node_modules/bin-links": {
-      "version": "2.2.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^4.0.1",
-        "mkdirp": "^1.0.3",
-        "npm-normalize-package-bin": "^1.0.0",
-        "read-cmd-shim": "^2.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/cacache": {
-      "version": "15.3.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/caseless": {
-      "version": "0.12.0",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "3.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "colors": "^1.1.2"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
-      "version": "4.2.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/cmd-shim": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/colors": {
-      "version": "1.4.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.5.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/dashdash": {
-      "version": "1.14.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/npm/node_modules/debug": {
-      "version": "4.3.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/npm/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/diff": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/extend": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/forever-agent": {
-      "version": "0.6.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1 || ^2.0.0",
-        "strip-ansi": "^3.0.1 || ^4.0.0",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/getpass": {
-      "version": "0.1.7",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/glob": {
-      "version": "7.2.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/har-schema": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/har-validator": {
-      "version": "5.1.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/http-signature": {
-      "version": "1.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/ignore-walk": {
-      "version": "3.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/npm/node_modules/indent-string": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/inflight": {
-      "version": "1.0.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/inherits": {
-      "version": "2.0.4",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/ini": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/init-package-json": {
-      "version": "2.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^8.1.5",
-        "promzard": "^0.3.0",
-        "read": "~1.0.1",
-        "read-package-json": "^4.1.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ip": {
-      "version": "1.1.5",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.7.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/isstream": {
-      "version": "0.1.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "0.1.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-schema": {
-      "version": "0.2.3",
-      "inBundle": true
-    },
-    "node_modules/npm/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/jsonparse": {
-      "version": "1.3.1",
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/jsprim": {
-      "version": "1.4.1",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/just-diff": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "4.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "2.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/disparity-colors": "^1.0.1",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "npm-package-arg": "^8.1.4",
-        "pacote": "^11.3.4",
-        "tar": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^2.3.0",
-        "@npmcli/ci-detect": "^1.3.0",
-        "@npmcli/run-script": "^1.8.4",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^8.1.2",
-        "pacote": "^11.3.1",
-        "proc-log": "^1.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^2.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "6.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "2.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/run-script": "^1.8.3",
-        "npm-package-arg": "^8.1.0",
-        "pacote": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-package-data": "^3.0.2",
-        "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^11.0.0",
-        "semver": "^7.1.3",
-        "ssri": "^8.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "3.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmteam": {
-      "version": "2.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmversion": {
-      "version": "1.2.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^2.0.7",
-        "@npmcli/run-script": "^1.8.4",
-        "json-parse-even-better-errors": "^2.3.1",
-        "semver": "^7.3.5",
-        "stringify-package": "^1.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/mime-db": {
-      "version": "1.49.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.32",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.49.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch": {
-      "version": "3.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp": {
-      "version": "7.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
-        "nopt": "^5.0.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.2",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
-      "version": "1.2.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-      "version": "2.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
-      "version": "4.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "2.1.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "8.1.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
-        "validate-npm-package-name": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "2.2.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "ignore-walk": "^3.0.3",
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "6.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "5.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "11.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "make-fetch-happen": "^9.0.1",
-        "minipass": "^3.1.3",
-        "minipass-fetch": "^1.3.0",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.0.0",
-        "npm-package-arg": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/object-assign": {
-      "version": "4.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/once": {
-      "version": "1.4.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/p-map": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^2.1.0",
-        "@npmcli/installed-package-contents": "^1.0.6",
-        "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.8.2",
-        "cacache": "^15.0.5",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.3",
-        "mkdirp": "^1.0.3",
-        "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^2.1.4",
-        "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^11.0.0",
-        "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^2.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0"
-      },
-      "bin": {
-        "pacote": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "just-diff": "^3.0.1",
-        "just-diff-apply": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/performance-now": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/proc-log": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "1"
-      }
-    },
-    "node_modules/npm/node_modules/psl": {
-      "version": "1.8.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/punycode": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "inBundle": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/npm/node_modules/qs": {
-      "version": "6.5.2",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "4.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^3.0.0",
-        "npm-normalize-package-bin": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
-      }
-    },
-    "node_modules/npm/node_modules/request": {
-      "version": "2.88.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/semver": {
-      "version": "7.3.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.3",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks": {
-      "version": "2.6.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "6.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.10",
-      "inBundle": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sshpk": {
-      "version": "1.16.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/ssri": {
-      "version": "8.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/stringify-package": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/text-table": {
-      "version": "0.2.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/treeverse": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "inBundle": true,
-      "license": "Unlicense"
-    },
-    "node_modules/npm/node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/npm/node_modules/uri-js": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/uuid": {
-      "version": "3.4.0",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/npm/node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/npm/node_modules/wrappy": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/nwsapi": {
       "version": "2.2.0",
@@ -17730,15 +15067,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/agent-base": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17750,8 +15083,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/agentkeepalive": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17763,8 +15094,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ansi-align": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17773,8 +15102,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17783,8 +15110,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17796,36 +15121,26 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/are-we-there-yet": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -17835,8 +15150,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17851,8 +15164,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17861,15 +15172,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17878,8 +15185,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17888,15 +15193,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -17905,22 +15206,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/aws4": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -17930,8 +15225,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/bin-links": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
-      "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
       "inBundle": true,
       "license": "Artistic-2.0",
       "dependencies": {
@@ -17945,15 +15238,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/bluebird": {
       "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/boxen": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17971,8 +15260,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17982,22 +15269,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/buffer-from": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/builtins": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/byline": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18006,8 +15287,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/byte-size": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
-      "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18016,8 +15295,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cacache": {
       "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18040,15 +15317,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/call-limit": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
-      "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/camelcase": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18057,8 +15330,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18067,15 +15338,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/chalk": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18089,22 +15356,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cidr-regex": {
       "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
-      "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -18116,8 +15377,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cli-boxes": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18126,8 +15385,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cli-columns": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
-      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18140,8 +15397,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cli-table3": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18157,8 +15412,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18169,8 +15422,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18179,8 +15430,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18189,8 +15438,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18204,8 +15451,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18217,8 +15462,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18227,8 +15470,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cmd-shim": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
-      "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18238,8 +15479,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18248,8 +15487,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/color-convert": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18258,15 +15495,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/colors": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18276,8 +15509,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18287,8 +15518,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18300,15 +15529,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -18323,8 +15548,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18339,8 +15562,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18349,8 +15570,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/config-chain": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "inBundle": true,
       "dependencies": {
         "ini": "^1.3.4",
@@ -18359,8 +15578,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/configstore": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
-      "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -18377,15 +15594,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18399,29 +15612,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18433,8 +15638,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18445,8 +15648,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18456,15 +15657,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18473,14 +15670,10 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/cyclist": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "inBundle": true
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18492,8 +15685,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/debug": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18502,15 +15693,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18519,8 +15706,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18529,8 +15714,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18539,8 +15722,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18549,8 +15730,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18559,8 +15738,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18572,8 +15749,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18582,15 +15757,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/detect-indent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18599,8 +15770,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18609,8 +15778,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -18620,8 +15787,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/dot-prop": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18633,8 +15798,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/dotenv": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -18643,15 +15806,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/duplexify": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18663,8 +15822,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18679,8 +15836,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18689,8 +15844,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -18701,22 +15854,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/editor": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-      "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18725,8 +15872,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18735,8 +15880,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/env-paths": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18745,15 +15888,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/err-code": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18765,8 +15904,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/es-abstract": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18782,8 +15919,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18797,15 +15932,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18814,8 +15945,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18824,8 +15953,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/execa": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18843,8 +15970,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/execa/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -18853,15 +15978,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -18870,29 +15991,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/figgy-pudding": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/find-npm-prefix": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/flush-write-stream": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18902,8 +16015,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18918,8 +16029,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18928,8 +16037,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -18938,8 +16045,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/form-data": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18953,8 +16058,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18964,8 +16067,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18980,8 +16081,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -18990,8 +16089,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19000,8 +16097,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19011,8 +16106,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-vacuum": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19023,8 +16116,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19036,15 +16127,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19059,8 +16146,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19069,22 +16154,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19100,15 +16179,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gauge/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gauge/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19122,15 +16197,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/genfun": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gentle-fs": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
-      "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
       "inBundle": true,
       "license": "Artistic-2.0",
       "dependencies": {
@@ -19149,22 +16220,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -19173,8 +16238,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19186,8 +16249,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19196,8 +16257,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/glob": {
       "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19217,8 +16276,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19230,8 +16287,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19253,8 +16308,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/got/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19263,15 +16316,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -19280,8 +16329,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/har-validator": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "inBundle": true,
       "license": "MIT",
@@ -19295,8 +16342,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/har-validator/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19312,22 +16357,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19339,8 +16378,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19349,8 +16386,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19359,29 +16394,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/http-cache-semantics": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/http-proxy-agent": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19394,8 +16421,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19410,8 +16435,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/https-proxy-agent": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19424,8 +16447,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19434,8 +16455,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/iconv-lite": {
       "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19447,8 +16466,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/iferr": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
-      "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19457,8 +16474,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19467,8 +16482,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19477,8 +16490,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19487,15 +16498,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19505,22 +16512,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/init-package-json": {
       "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19536,15 +16537,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19553,8 +16550,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-callable": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19563,8 +16558,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-ci": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19576,15 +16569,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-cidr": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
-      "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -19596,8 +16585,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19606,8 +16593,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19619,8 +16604,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-installed-globally": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19633,8 +16616,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-npm": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19643,8 +16624,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19653,8 +16632,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19666,8 +16643,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19676,8 +16651,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-regex": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19689,8 +16662,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19699,8 +16670,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19709,8 +16678,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19722,65 +16689,47 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/json-schema": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "inBundle": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "engines": [
         "node >= 0.2.0"
       ],
@@ -19789,8 +16738,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "inBundle": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
@@ -19806,8 +16753,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/jsprim": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19822,8 +16767,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/latest-version": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19835,15 +16778,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lazy-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-      "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libcipm": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
-      "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19866,8 +16805,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpm": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
-      "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19895,8 +16832,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmaccess": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
-      "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19908,8 +16843,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19920,8 +16853,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19933,8 +16864,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19947,8 +16876,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19960,8 +16887,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19973,8 +16898,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19983,8 +16906,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmhook": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
-      "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -19996,8 +16917,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmorg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
-      "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20009,8 +16928,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmpublish": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
-      "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20027,8 +16944,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmsearch": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
-      "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20039,8 +16954,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpmteam": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
-      "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20052,8 +16965,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/libnpx": {
       "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
-      "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20072,8 +16983,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lock-verify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
-      "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20083,8 +16992,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lockfile": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20093,15 +17000,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._baseuniq": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20111,22 +17014,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20135,64 +17032,46 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._createset": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash._root": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.union": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lodash.without": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20201,8 +17080,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20211,8 +17088,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/make-dir": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20224,8 +17099,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/make-fetch-happen": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
-      "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20244,15 +17117,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/meant": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
-      "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mime-db": {
       "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20261,8 +17130,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mime-types": {
       "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20274,8 +17141,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20287,15 +17152,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/minimist": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/minizlib": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20304,8 +17165,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20315,8 +17174,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -20337,8 +17194,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20350,15 +17205,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20372,29 +17223,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/node-fetch-npm": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20408,8 +17251,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/node-gyp": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
-      "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20434,8 +17275,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/nopt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20448,8 +17287,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -20461,8 +17298,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20471,8 +17306,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-audit-report": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
-      "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20482,8 +17315,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20492,15 +17323,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-cache-filename": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-      "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-install-checks": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
-      "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -20509,8 +17336,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-lifecycle": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
-      "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
       "inBundle": true,
       "license": "Artistic-2.0",
       "dependencies": {
@@ -20526,22 +17351,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-logical-tree": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-package-arg": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
-      "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20553,8 +17372,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20565,8 +17382,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
-      "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20577,8 +17392,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-profile": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
-      "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20589,8 +17402,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
-      "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20605,8 +17416,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -20626,8 +17435,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20639,15 +17446,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
-      "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20659,8 +17462,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20669,8 +17470,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -20679,8 +17478,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20689,8 +17486,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/object-keys": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20699,8 +17494,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20713,8 +17506,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20723,8 +17514,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -20733,8 +17522,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20743,8 +17530,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20753,8 +17538,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20764,8 +17547,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20774,8 +17555,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/package-json": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20790,8 +17569,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pacote": {
       "version": "9.5.12",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
-      "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20829,8 +17606,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pacote/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20840,8 +17615,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/parallel-transform": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20852,8 +17625,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20868,8 +17639,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20878,8 +17647,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20888,8 +17655,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20898,15 +17663,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20915,22 +17676,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20939,8 +17694,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20949,22 +17702,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -20977,8 +17724,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/promise-retry/node_modules/retry": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -20987,8 +17732,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -20997,15 +17740,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/proto-list": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/protoduck": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
-      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21014,29 +17753,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/psl": {
       "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21046,8 +17777,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21058,8 +17787,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21069,15 +17796,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -21085,8 +17808,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -21095,8 +17816,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/query-string": {
       "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
-      "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21110,15 +17829,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/qw": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-      "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
@@ -21133,8 +17848,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21146,8 +17859,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/read-cmd-shim": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
-      "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21156,8 +17867,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/read-installed": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21174,8 +17883,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/read-package-json": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-      "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21190,8 +17897,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/read-package-tree": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
-      "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21202,8 +17907,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21217,8 +17920,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21230,8 +17931,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/registry-auth-token": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21241,8 +17940,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/registry-url": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21254,8 +17951,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/request": {
       "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21286,8 +17981,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21296,15 +17989,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21313,8 +18002,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21323,8 +18010,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/rimraf": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21336,8 +18021,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21346,29 +18029,21 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/run-queue/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -21377,8 +18052,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21390,15 +18063,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sha": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
-      "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT)",
       "dependencies": {
@@ -21407,8 +18076,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21420,8 +18087,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21430,15 +18095,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/slide": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21447,8 +18108,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/smart-buffer": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21458,8 +18117,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/socks": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21473,8 +18130,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21487,8 +18142,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21500,15 +18153,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-object": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-      "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-union-stream": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-      "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21518,8 +18167,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-      "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21529,15 +18176,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21549,15 +18192,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/spdx-correct": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21567,15 +18206,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21585,15 +18220,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/split-on-first": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21602,8 +18233,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/sshpk": {
       "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21630,8 +18259,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/ssri": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21640,8 +18267,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stream-each": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21651,8 +18276,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stream-iterate": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-      "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21662,8 +18285,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21678,8 +18299,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21688,15 +18307,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/strict-uri-encode": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21705,8 +18320,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21715,15 +18328,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21736,8 +18345,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21746,8 +18353,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21756,8 +18361,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21769,15 +18372,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/stringify-package": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21789,8 +18388,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21799,8 +18396,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21809,8 +18404,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/supports-color": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21822,8 +18415,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tar": {
       "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21841,8 +18432,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21852,8 +18441,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tar/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -21873,15 +18460,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tar/node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/term-size": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21893,22 +18476,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/through2": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21918,8 +18495,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/through2/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21934,8 +18509,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21944,8 +18517,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/timed-out": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -21954,15 +18525,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-      "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -21975,8 +18542,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21988,23 +18553,17 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "inBundle": true,
       "license": "Unlicense",
       "optional": true
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/uid-number": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22013,15 +18572,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/umask": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22030,8 +18585,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22040,8 +18593,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/unique-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22053,8 +18604,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22063,8 +18612,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/unzip-response": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22073,8 +18620,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/update-notifier": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22095,8 +18640,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/uri-js": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22105,8 +18648,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/uri-js/node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22115,8 +18656,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22128,22 +18667,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/util-extend": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/util-promisify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-      "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22152,8 +18685,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/uuid": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -22162,8 +18693,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22173,8 +18702,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22183,8 +18710,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -22198,8 +18723,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22208,8 +18731,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22221,15 +18742,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wide-align": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22238,8 +18755,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wide-align/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22253,8 +18768,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/widest-line": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22266,8 +18779,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22276,8 +18787,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22291,8 +18800,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22301,8 +18808,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22311,8 +18816,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22326,8 +18829,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22339,15 +18840,11 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22358,8 +18855,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22368,8 +18863,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/xtend": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22378,22 +18871,16 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/y18n": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs": {
       "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22412,8 +18899,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs-parser": {
       "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22423,8 +18908,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22433,8 +18916,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22443,8 +18924,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22456,8 +18935,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22466,8 +18943,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22480,8 +18955,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22496,8 +18969,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22509,8 +18980,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22519,8 +18988,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22534,8 +19001,6 @@
     },
     "node_modules/sauce-testrunner-utils/node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25094,26 +21559,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -34874,1840 +31319,6 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
     },
-    "npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
-      "requires": {
-        "@isaacs/string-locale-compare": "*",
-        "@npmcli/arborist": "*",
-        "@npmcli/ci-detect": "*",
-        "@npmcli/config": "*",
-        "@npmcli/map-workspaces": "*",
-        "@npmcli/package-json": "*",
-        "@npmcli/run-script": "*",
-        "abbrev": "*",
-        "ansicolors": "*",
-        "ansistyles": "*",
-        "archy": "*",
-        "cacache": "*",
-        "chalk": "*",
-        "chownr": "*",
-        "cli-columns": "*",
-        "cli-table3": "*",
-        "columnify": "*",
-        "fastest-levenshtein": "*",
-        "glob": "*",
-        "graceful-fs": "*",
-        "hosted-git-info": "*",
-        "ini": "*",
-        "init-package-json": "*",
-        "is-cidr": "*",
-        "json-parse-even-better-errors": "*",
-        "libnpmaccess": "*",
-        "libnpmdiff": "*",
-        "libnpmexec": "*",
-        "libnpmfund": "*",
-        "libnpmhook": "*",
-        "libnpmorg": "*",
-        "libnpmpack": "*",
-        "libnpmpublish": "*",
-        "libnpmsearch": "*",
-        "libnpmteam": "*",
-        "libnpmversion": "*",
-        "make-fetch-happen": "*",
-        "minipass": "*",
-        "minipass-pipeline": "*",
-        "mkdirp": "*",
-        "mkdirp-infer-owner": "*",
-        "ms": "*",
-        "node-gyp": "*",
-        "nopt": "*",
-        "npm-audit-report": "*",
-        "npm-install-checks": "*",
-        "npm-package-arg": "*",
-        "npm-pick-manifest": "*",
-        "npm-profile": "*",
-        "npm-registry-fetch": "*",
-        "npm-user-validate": "*",
-        "npmlog": "*",
-        "opener": "*",
-        "pacote": "*",
-        "parse-conflict-json": "*",
-        "qrcode-terminal": "*",
-        "read": "*",
-        "read-package-json": "*",
-        "read-package-json-fast": "*",
-        "readdir-scoped-modules": "*",
-        "rimraf": "*",
-        "semver": "*",
-        "ssri": "*",
-        "tar": "*",
-        "text-table": "*",
-        "tiny-relative-date": "*",
-        "treeverse": "*",
-        "validate-npm-package-name": "*",
-        "which": "*",
-        "write-file-atomic": "*"
-      },
-      "dependencies": {
-        "@colors/colors": {
-          "version": "1.5.0",
-          "optional": true
-        },
-        "@gar/promisify": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "@isaacs/string-locale-compare": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "@npmcli/arborist": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "@isaacs/string-locale-compare": "^1.0.1",
-            "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^1.0.2",
-            "@npmcli/metavuln-calculator": "^1.1.0",
-            "@npmcli/move-file": "^1.1.0",
-            "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^1.0.1",
-            "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^1.8.2",
-            "bin-links": "^2.2.1",
-            "cacache": "^15.0.3",
-            "common-ancestor-path": "^1.0.1",
-            "json-parse-even-better-errors": "^2.3.1",
-            "json-stringify-nice": "^1.1.4",
-            "mkdirp": "^1.0.4",
-            "mkdirp-infer-owner": "^2.0.0",
-            "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.5",
-            "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.3.5",
-            "parse-conflict-json": "^1.1.1",
-            "proc-log": "^1.0.0",
-            "promise-all-reject-late": "^1.0.0",
-            "promise-call-limit": "^1.0.1",
-            "read-package-json-fast": "^2.0.2",
-            "readdir-scoped-modules": "^1.1.0",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
-            "ssri": "^8.0.1",
-            "treeverse": "^1.0.4",
-            "walk-up-path": "^1.0.0"
-          }
-        },
-        "@npmcli/ci-detect": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "@npmcli/config": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "ini": "^2.0.0",
-            "mkdirp-infer-owner": "^2.0.0",
-            "nopt": "^5.0.0",
-            "semver": "^7.3.4",
-            "walk-up-path": "^1.0.0"
-          }
-        },
-        "@npmcli/disparity-colors": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^4.3.0"
-          }
-        },
-        "@npmcli/fs": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "@gar/promisify": "^1.0.1",
-            "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/git": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "@npmcli/promise-spawn": "^1.3.2",
-            "lru-cache": "^6.0.0",
-            "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^6.1.1",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^2.0.1",
-            "semver": "^7.3.5",
-            "which": "^2.0.2"
-          }
-        },
-        "@npmcli/installed-package-contents": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "npm-bundled": "^1.1.1",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "@npmcli/map-workspaces": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.1.6",
-            "minimatch": "^3.0.4",
-            "read-package-json-fast": "^2.0.1"
-          }
-        },
-        "@npmcli/metavuln-calculator": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "cacache": "^15.0.5",
-            "pacote": "^11.1.11",
-            "semver": "^7.3.2"
-          }
-        },
-        "@npmcli/move-file": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "mkdirp": "^1.0.4",
-            "rimraf": "^3.0.2"
-          }
-        },
-        "@npmcli/name-from-folder": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "@npmcli/node-gyp": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "@npmcli/package-json": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "json-parse-even-better-errors": "^2.3.1"
-          }
-        },
-        "@npmcli/promise-spawn": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "infer-owner": "^1.0.4"
-          }
-        },
-        "@npmcli/run-script": {
-          "version": "1.8.6",
-          "bundled": true,
-          "requires": {
-            "@npmcli/node-gyp": "^1.0.2",
-            "@npmcli/promise-spawn": "^1.3.2",
-            "node-gyp": "^7.1.0",
-            "read-package-json-fast": "^2.0.1"
-          }
-        },
-        "@tootallnate/once": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "agent-base": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "agentkeepalive": {
-          "version": "4.1.4",
-          "bundled": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "depd": "^1.1.2",
-            "humanize-ms": "^1.2.1"
-          }
-        },
-        "aggregate-error": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^4.0.0"
-          }
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "bundled": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.6",
-          "bundled": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.11.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "bin-links": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "cmd-shim": "^4.0.1",
-            "mkdirp": "^1.0.3",
-            "npm-normalize-package-bin": "^1.0.0",
-            "read-cmd-shim": "^2.0.0",
-            "rimraf": "^3.0.0",
-            "write-file-atomic": "^3.0.3"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtins": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "cacache": {
-          "version": "15.3.0",
-          "bundled": true,
-          "requires": {
-            "@npmcli/fs": "^1.0.0",
-            "@npmcli/move-file": "^1.0.1",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
-            "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.0.2",
-            "unique-filename": "^1.1.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "chownr": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "cidr-regex": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "ip-regex": "^4.1.0"
-          }
-        },
-        "clean-stack": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "cli-columns": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "cli-table3": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
-            "string-width": "^4.2.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "4.2.2",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
-          }
-        },
-        "clone": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "cmd-shim": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "mkdirp-infer-owner": "^2.0.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "bundled": true
-        },
-        "color-support": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "colors": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "columnify": {
-          "version": "1.5.4",
-          "bundled": true,
-          "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "common-ancestor-path": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.2",
-          "bundled": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "debuglog": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "defaults": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "clone": "^1.0.2"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "depd": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "dezalgo": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
-          }
-        },
-        "diff": {
-          "version": "5.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "bundled": true
-        },
-        "encoding": {
-          "version": "0.1.13",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "iconv-lite": "^0.6.2"
-          }
-        },
-        "env-paths": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "err-code": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "fastest-levenshtein": {
-          "version": "1.0.12",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "fs-minipass": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "gauge": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.1",
-            "object-assign": "^4.1.1",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1 || ^2.0.0",
-            "strip-ansi": "^3.0.1 || ^4.0.0",
-            "wide-align": "^1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.2.0",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.8",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "bundled": true,
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "has": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "http-cache-semantics": {
-          "version": "4.1.0",
-          "bundled": true
-        },
-        "http-proxy-agent": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "@tootallnate/once": "1",
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "humanize-ms": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "ms": "^2.0.0"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "indent-string": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "infer-owner": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "ini": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "init-package-json": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "npm-package-arg": "^8.1.5",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "^4.1.1",
-            "semver": "^7.3.5",
-            "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "ip": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "ip-regex": {
-          "version": "4.3.0",
-          "bundled": true
-        },
-        "is-cidr": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "cidr-regex": "^3.1.1"
-          }
-        },
-        "is-core-module": {
-          "version": "2.7.0",
-          "bundled": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-lambda": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "json-parse-even-better-errors": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "bundled": true
-        },
-        "json-stringify-nice": {
-          "version": "1.1.4",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonparse": {
-          "version": "1.3.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "just-diff": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "just-diff-apply": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "libnpmaccess": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "minipass": "^3.1.1",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmdiff": {
-          "version": "2.0.4",
-          "bundled": true,
-          "requires": {
-            "@npmcli/disparity-colors": "^1.0.1",
-            "@npmcli/installed-package-contents": "^1.0.7",
-            "binary-extensions": "^2.2.0",
-            "diff": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
-            "tar": "^6.1.0"
-          }
-        },
-        "libnpmexec": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "@npmcli/arborist": "^2.3.0",
-            "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^1.8.4",
-            "chalk": "^4.1.0",
-            "mkdirp-infer-owner": "^2.0.0",
-            "npm-package-arg": "^8.1.2",
-            "pacote": "^11.3.1",
-            "proc-log": "^1.0.0",
-            "read": "^1.0.7",
-            "read-package-json-fast": "^2.0.2",
-            "walk-up-path": "^1.0.0"
-          }
-        },
-        "libnpmfund": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "@npmcli/arborist": "^2.5.0"
-          }
-        },
-        "libnpmhook": {
-          "version": "6.0.3",
-          "bundled": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmorg": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmpack": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "@npmcli/run-script": "^1.8.3",
-            "npm-package-arg": "^8.1.0",
-            "pacote": "^11.2.6"
-          }
-        },
-        "libnpmpublish": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "normalize-package-data": "^3.0.2",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0",
-            "semver": "^7.1.3",
-            "ssri": "^8.0.1"
-          }
-        },
-        "libnpmsearch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmteam": {
-          "version": "2.0.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmversion": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^1.8.4",
-            "json-parse-even-better-errors": "^2.3.1",
-            "semver": "^7.3.5",
-            "stringify-package": "^1.0.1"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-fetch-happen": {
-          "version": "9.1.0",
-          "bundled": true,
-          "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
-            "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^4.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.2",
-            "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.49.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.32",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.49.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minipass": {
-          "version": "3.1.5",
-          "bundled": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minipass-collect": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-fetch": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
-            "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
-          }
-        },
-        "minipass-flush": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-json-stream": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "^1.3.1",
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-pipeline": {
-          "version": "1.2.4",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minipass-sized": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "2.1.2",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.0.0",
-            "yallist": "^4.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "mkdirp-infer-owner": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "infer-owner": "^1.0.4",
-            "mkdirp": "^1.0.3"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "bundled": true
-        },
-        "mute-stream": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "negotiator": {
-          "version": "0.6.2",
-          "bundled": true
-        },
-        "node-gyp": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
-            "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
-            "which": "^2.0.2"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "nopt": {
-          "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "normalize-package-data": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^4.0.1",
-            "is-core-module": "^2.5.0",
-            "semver": "^7.3.4",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "npm-audit-report": {
-          "version": "2.1.5",
-          "bundled": true,
-          "requires": {
-            "chalk": "^4.0.0"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-install-checks": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "semver": "^7.1.1"
-          }
-        },
-        "npm-normalize-package-bin": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "npm-package-arg": {
-          "version": "8.1.5",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^4.0.1",
-            "semver": "^7.3.4",
-            "validate-npm-package-name": "^3.0.0"
-          }
-        },
-        "npm-packlist": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.6",
-            "ignore-walk": "^3.0.3",
-            "npm-bundled": "^1.1.1",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "npm-pick-manifest": {
-          "version": "6.1.1",
-          "bundled": true,
-          "requires": {
-            "npm-install-checks": "^4.0.0",
-            "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^8.1.2",
-            "semver": "^7.3.4"
-          }
-        },
-        "npm-profile": {
-          "version": "5.0.4",
-          "bundled": true,
-          "requires": {
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "npm-registry-fetch": {
-          "version": "11.0.0",
-          "bundled": true,
-          "requires": {
-            "make-fetch-happen": "^9.0.1",
-            "minipass": "^3.1.3",
-            "minipass-fetch": "^1.3.0",
-            "minipass-json-stream": "^1.0.1",
-            "minizlib": "^2.0.0",
-            "npm-package-arg": "^8.0.0"
-          }
-        },
-        "npm-user-validate": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "npmlog": {
-          "version": "5.0.1",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "^2.0.0",
-            "console-control-strings": "^1.1.0",
-            "gauge": "^3.0.0",
-            "set-blocking": "^2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "opener": {
-          "version": "1.5.2",
-          "bundled": true
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "pacote": {
-          "version": "11.3.5",
-          "bundled": true,
-          "requires": {
-            "@npmcli/git": "^2.1.0",
-            "@npmcli/installed-package-contents": "^1.0.6",
-            "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^1.8.2",
-            "cacache": "^15.0.5",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.1.0",
-            "infer-owner": "^1.0.4",
-            "minipass": "^3.1.3",
-            "mkdirp": "^1.0.3",
-            "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^2.1.4",
-            "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^11.0.0",
-            "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^2.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.1.0"
-          }
-        },
-        "parse-conflict-json": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "just-diff": "^3.0.1",
-            "just-diff-apply": "^3.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "proc-log": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "promise-all-reject-late": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "promise-call-limit": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "promise-retry": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "err-code": "^2.0.2",
-            "retry": "^0.12.0"
-          }
-        },
-        "promzard": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "read": "1"
-          }
-        },
-        "psl": {
-          "version": "1.8.0",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "qrcode-terminal": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.2",
-          "bundled": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "mute-stream": "~0.0.4"
-          }
-        },
-        "read-cmd-shim": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "read-package-json": {
-          "version": "4.1.1",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "normalize-package-data": "^3.0.0",
-            "npm-normalize-package-bin": "^1.0.0"
-          }
-        },
-        "read-package-json-fast": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "npm-normalize-package-bin": "^1.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "readdir-scoped-modules": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
-          }
-        },
-        "request": {
-          "version": "2.88.2",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.5.0",
-              "bundled": true,
-              "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-              }
-            }
-          }
-        },
-        "retry": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "smart-buffer": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "socks": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
-          }
-        },
-        "socks-proxy-agent": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "agent-base": "^6.0.2",
-            "debug": "^4.3.1",
-            "socks": "^2.6.1"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.3.0",
-          "bundled": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.10",
-          "bundled": true
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
-        },
-        "ssri": {
-          "version": "8.0.1",
-          "bundled": true,
-          "requires": {
-            "minipass": "^3.1.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "stringify-package": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tar": {
-          "version": "6.1.11",
-          "bundled": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^3.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "tiny-relative-date": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "treeverse": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true
-        },
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "bundled": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
-        },
-        "unique-filename": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "unique-slug": "^2.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
-        },
-        "walk-up-path": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "wcwidth": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "defaults": "^1.0.3"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true
-        }
-      }
-    },
     "npm-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
@@ -38630,14 +33241,10 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "bundled": true
             },
             "agent-base": {
               "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-              "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
               "bundled": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
@@ -38645,8 +33252,6 @@
             },
             "agentkeepalive": {
               "version": "3.5.2",
-              "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-              "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
               "bundled": true,
               "requires": {
                 "humanize-ms": "^1.2.1"
@@ -38654,8 +33259,6 @@
             },
             "ansi-align": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-              "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
               "bundled": true,
               "requires": {
                 "string-width": "^2.0.0"
@@ -38663,14 +33266,10 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true
             },
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "bundled": true,
               "requires": {
                 "color-convert": "^1.9.0"
@@ -38678,32 +33277,22 @@
             },
             "ansicolors": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "bundled": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "bundled": true
             },
             "aproba": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-              "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
               "bundled": true
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "bundled": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "bundled": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -38712,8 +33301,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -38727,8 +33314,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -38738,14 +33323,10 @@
             },
             "asap": {
               "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-              "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
               "bundled": true
             },
             "asn1": {
               "version": "0.2.4",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-              "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
               "bundled": true,
               "requires": {
                 "safer-buffer": "~2.1.0"
@@ -38753,38 +33334,26 @@
             },
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "bundled": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
               "bundled": true
             },
             "aws-sign2": {
               "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
               "bundled": true
             },
             "aws4": {
               "version": "1.8.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-              "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
               "bundled": true
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "bundled": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-              "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -38793,8 +33362,6 @@
             },
             "bin-links": {
               "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
-              "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.3",
@@ -38807,14 +33374,10 @@
             },
             "bluebird": {
               "version": "3.5.5",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-              "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
               "bundled": true
             },
             "boxen": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-              "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
               "bundled": true,
               "requires": {
                 "ansi-align": "^2.0.0",
@@ -38828,8 +33391,6 @@
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -38838,32 +33399,22 @@
             },
             "buffer-from": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-              "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
               "bundled": true
             },
             "builtins": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
               "bundled": true
             },
             "byline": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
               "bundled": true
             },
             "byte-size": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
-              "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
               "bundled": true
             },
             "cacache": {
               "version": "12.0.3",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-              "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.5",
@@ -38885,32 +33436,22 @@
             },
             "call-limit": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
-              "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
               "bundled": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "bundled": true
             },
             "capture-stack-trace": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
               "bundled": true
             },
             "caseless": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "bundled": true
             },
             "chalk": {
               "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "bundled": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
@@ -38920,20 +33461,14 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
               "bundled": true
             },
             "ci-info": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-              "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
               "bundled": true
             },
             "cidr-regex": {
               "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
-              "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
               "bundled": true,
               "requires": {
                 "ip-regex": "^2.1.0"
@@ -38941,14 +33476,10 @@
             },
             "cli-boxes": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-              "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
               "bundled": true
             },
             "cli-columns": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
-              "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
               "bundled": true,
               "requires": {
                 "string-width": "^2.0.0",
@@ -38957,8 +33488,6 @@
             },
             "cli-table3": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-              "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
               "bundled": true,
               "requires": {
                 "colors": "^1.1.2",
@@ -38968,8 +33497,6 @@
             },
             "cliui": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-              "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
               "bundled": true,
               "requires": {
                 "string-width": "^3.1.0",
@@ -38979,20 +33506,14 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-                  "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
                   "bundled": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                  "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                   "bundled": true,
                   "requires": {
                     "emoji-regex": "^7.0.1",
@@ -39002,8 +33523,6 @@
                 },
                 "strip-ansi": {
                   "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                  "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                   "bundled": true,
                   "requires": {
                     "ansi-regex": "^4.1.0"
@@ -39013,14 +33532,10 @@
             },
             "clone": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
               "bundled": true
             },
             "cmd-shim": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
-              "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -39029,14 +33544,10 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "bundled": true
             },
             "color-convert": {
               "version": "1.9.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-              "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
               "bundled": true,
               "requires": {
                 "color-name": "^1.1.1"
@@ -39044,21 +33555,15 @@
             },
             "color-name": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
               "bundled": true
             },
             "colors": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-              "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
               "bundled": true,
               "optional": true
             },
             "columnify": {
               "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "bundled": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
@@ -39067,8 +33572,6 @@
             },
             "combined-stream": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
               "bundled": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -39076,14 +33579,10 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "bundled": true
             },
             "concat-stream": {
               "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-              "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
               "bundled": true,
               "requires": {
                 "buffer-from": "^1.0.0",
@@ -39094,8 +33593,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -39109,8 +33606,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -39120,8 +33615,6 @@
             },
             "config-chain": {
               "version": "1.1.12",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-              "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
               "bundled": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -39130,8 +33623,6 @@
             },
             "configstore": {
               "version": "3.1.5",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
-              "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
               "bundled": true,
               "requires": {
                 "dot-prop": "^4.2.1",
@@ -39144,14 +33635,10 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "bundled": true
             },
             "copy-concurrently": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-              "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.1",
@@ -39164,28 +33651,20 @@
               "dependencies": {
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true
                 },
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                   "bundled": true
                 }
               }
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "bundled": true
             },
             "create-error-class": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
               "bundled": true,
               "requires": {
                 "capture-stack-trace": "^1.0.0"
@@ -39193,8 +33672,6 @@
             },
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "bundled": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -39204,8 +33681,6 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.5",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                  "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
                   "bundled": true,
                   "requires": {
                     "pseudomap": "^1.0.2",
@@ -39214,28 +33689,20 @@
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "bundled": true
                 }
               }
             },
             "crypto-random-string": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-              "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
               "bundled": true
             },
             "cyclist": {
               "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-              "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
               "bundled": true
             },
             "dashdash": {
               "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "bundled": true,
               "requires": {
                 "assert-plus": "^1.0.0"
@@ -39243,8 +33710,6 @@
             },
             "debug": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "bundled": true,
               "requires": {
                 "ms": "2.0.0"
@@ -39252,40 +33717,28 @@
               "dependencies": {
                 "ms": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                   "bundled": true
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "bundled": true
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
               "bundled": true
             },
             "decode-uri-component": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
               "bundled": true
             },
             "deep-extend": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "bundled": true
             },
             "defaults": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-              "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
               "bundled": true,
               "requires": {
                 "clone": "^1.0.2"
@@ -39293,8 +33746,6 @@
             },
             "define-properties": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-              "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
               "bundled": true,
               "requires": {
                 "object-keys": "^1.0.12"
@@ -39302,32 +33753,22 @@
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
               "bundled": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "bundled": true
             },
             "detect-indent": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
               "bundled": true
             },
             "detect-newline": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-              "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
               "bundled": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "bundled": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -39336,8 +33777,6 @@
             },
             "dot-prop": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-              "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
               "bundled": true,
               "requires": {
                 "is-obj": "^1.0.0"
@@ -39345,20 +33784,14 @@
             },
             "dotenv": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-              "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
               "bundled": true
             },
             "duplexer3": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
               "bundled": true
             },
             "duplexify": {
               "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-              "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
               "bundled": true,
               "requires": {
                 "end-of-stream": "^1.0.0",
@@ -39369,8 +33802,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -39384,8 +33815,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -39395,8 +33824,6 @@
             },
             "ecc-jsbn": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-              "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
               "bundled": true,
               "optional": true,
               "requires": {
@@ -39406,20 +33833,14 @@
             },
             "editor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "bundled": true
             },
             "emoji-regex": {
               "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
               "bundled": true
             },
             "encoding": {
               "version": "0.1.12",
-              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-              "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
               "bundled": true,
               "requires": {
                 "iconv-lite": "~0.4.13"
@@ -39427,8 +33848,6 @@
             },
             "end-of-stream": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
               "bundled": true,
               "requires": {
                 "once": "^1.4.0"
@@ -39436,20 +33855,14 @@
             },
             "env-paths": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-              "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
               "bundled": true
             },
             "err-code": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
               "bundled": true
             },
             "errno": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-              "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
               "bundled": true,
               "requires": {
                 "prr": "~1.0.1"
@@ -39457,8 +33870,6 @@
             },
             "es-abstract": {
               "version": "1.12.0",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-              "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
               "bundled": true,
               "requires": {
                 "es-to-primitive": "^1.1.1",
@@ -39470,8 +33881,6 @@
             },
             "es-to-primitive": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-              "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
               "bundled": true,
               "requires": {
                 "is-callable": "^1.1.4",
@@ -39481,14 +33890,10 @@
             },
             "es6-promise": {
               "version": "4.2.8",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-              "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
               "bundled": true
             },
             "es6-promisify": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
               "bundled": true,
               "requires": {
                 "es6-promise": "^4.0.3"
@@ -39496,14 +33901,10 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
               "bundled": true
             },
             "execa": {
               "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
               "bundled": true,
               "requires": {
                 "cross-spawn": "^5.0.1",
@@ -39517,46 +33918,32 @@
               "dependencies": {
                 "get-stream": {
                   "version": "3.0.0",
-                  "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                  "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                   "bundled": true
                 }
               }
             },
             "extend": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-              "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
               "bundled": true
             },
             "extsprintf": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
               "bundled": true
             },
             "fast-json-stable-stringify": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-              "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
               "bundled": true
             },
             "figgy-pudding": {
               "version": "3.5.1",
-              "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-              "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
               "bundled": true
             },
             "find-npm-prefix": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-              "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
               "bundled": true
             },
             "flush-write-stream": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-              "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
               "bundled": true,
               "requires": {
                 "inherits": "^2.0.1",
@@ -39565,8 +33952,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -39580,8 +33965,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -39591,14 +33974,10 @@
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "bundled": true
             },
             "form-data": {
               "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
               "bundled": true,
               "requires": {
                 "asynckit": "^0.4.0",
@@ -39608,8 +33987,6 @@
             },
             "from2": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "bundled": true,
               "requires": {
                 "inherits": "^2.0.1",
@@ -39618,8 +33995,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -39633,8 +34008,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -39644,8 +34017,6 @@
             },
             "fs-minipass": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-              "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
               "bundled": true,
               "requires": {
                 "minipass": "^2.6.0"
@@ -39653,8 +34024,6 @@
               "dependencies": {
                 "minipass": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                  "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
@@ -39665,8 +34034,6 @@
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -39676,8 +34043,6 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -39688,14 +34053,10 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                   "bundled": true
                 },
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -39709,8 +34070,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -39720,20 +34079,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "bundled": true
             },
             "function-bind": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-              "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
               "bundled": true
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "bundled": true,
               "requires": {
                 "aproba": "^1.0.3",
@@ -39748,14 +34101,10 @@
               "dependencies": {
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "bundled": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -39767,14 +34116,10 @@
             },
             "genfun": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-              "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
               "bundled": true
             },
             "gentle-fs": {
               "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
-              "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.2",
@@ -39792,28 +34137,20 @@
               "dependencies": {
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true
                 },
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                   "bundled": true
                 }
               }
             },
             "get-caller-file": {
               "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-              "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
               "bundled": true
             },
             "get-stream": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "bundled": true,
               "requires": {
                 "pump": "^3.0.0"
@@ -39821,8 +34158,6 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "bundled": true,
               "requires": {
                 "assert-plus": "^1.0.0"
@@ -39830,8 +34165,6 @@
             },
             "glob": {
               "version": "7.1.6",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
               "bundled": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -39844,8 +34177,6 @@
             },
             "global-dirs": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-              "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
               "bundled": true,
               "requires": {
                 "ini": "^1.3.4"
@@ -39853,8 +34184,6 @@
             },
             "got": {
               "version": "6.7.1",
-              "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-              "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
               "bundled": true,
               "requires": {
                 "create-error-class": "^3.0.0",
@@ -39872,28 +34201,20 @@
               "dependencies": {
                 "get-stream": {
                   "version": "3.0.0",
-                  "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                  "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                   "bundled": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.2.4",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-              "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
               "bundled": true
             },
             "har-schema": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-              "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
               "bundled": true
             },
             "har-validator": {
               "version": "5.1.5",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-              "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
               "bundled": true,
               "requires": {
                 "ajv": "^6.12.3",
@@ -39902,8 +34223,6 @@
               "dependencies": {
                 "ajv": {
                   "version": "6.12.6",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-                  "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
                   "bundled": true,
                   "requires": {
                     "fast-deep-equal": "^3.1.1",
@@ -39914,22 +34233,16 @@
                 },
                 "fast-deep-equal": {
                   "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-                  "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
                   "bundled": true
                 },
                 "json-schema-traverse": {
                   "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                  "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                   "bundled": true
                 }
               }
             },
             "has": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-              "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
               "bundled": true,
               "requires": {
                 "function-bind": "^1.1.1"
@@ -39937,38 +34250,26 @@
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
               "bundled": true
             },
             "has-symbols": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-              "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
               "bundled": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "bundled": true
             },
             "hosted-git-info": {
               "version": "2.8.9",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "bundled": true
             },
             "http-cache-semantics": {
               "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-              "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
               "bundled": true
             },
             "http-proxy-agent": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-              "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
               "bundled": true,
               "requires": {
                 "agent-base": "4",
@@ -39977,8 +34278,6 @@
             },
             "http-signature": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "bundled": true,
               "requires": {
                 "assert-plus": "^1.0.0",
@@ -39988,8 +34287,6 @@
             },
             "https-proxy-agent": {
               "version": "2.2.4",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-              "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
               "bundled": true,
               "requires": {
                 "agent-base": "^4.3.0",
@@ -39998,8 +34295,6 @@
             },
             "humanize-ms": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-              "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
               "bundled": true,
               "requires": {
                 "ms": "^2.0.0"
@@ -40007,8 +34302,6 @@
             },
             "iconv-lite": {
               "version": "0.4.23",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-              "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
               "bundled": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -40016,14 +34309,10 @@
             },
             "iferr": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
-              "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
               "bundled": true
             },
             "ignore-walk": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-              "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
               "bundled": true,
               "requires": {
                 "minimatch": "^3.0.4"
@@ -40031,26 +34320,18 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
               "bundled": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "bundled": true
             },
             "infer-owner": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-              "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
               "bundled": true
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "bundled": true,
               "requires": {
                 "once": "^1.3.0",
@@ -40059,20 +34340,14 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
               "bundled": true
             },
             "ini": {
               "version": "1.3.8",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-              "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
               "bundled": true
             },
             "init-package-json": {
               "version": "1.10.3",
-              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-              "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
               "bundled": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -40087,26 +34362,18 @@
             },
             "ip": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
               "bundled": true
             },
             "ip-regex": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-              "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
               "bundled": true
             },
             "is-callable": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-              "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
               "bundled": true
             },
             "is-ci": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-              "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
               "bundled": true,
               "requires": {
                 "ci-info": "^1.5.0"
@@ -40114,16 +34381,12 @@
               "dependencies": {
                 "ci-info": {
                   "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-                  "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
                   "bundled": true
                 }
               }
             },
             "is-cidr": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
-              "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
               "bundled": true,
               "requires": {
                 "cidr-regex": "^2.0.10"
@@ -40131,14 +34394,10 @@
             },
             "is-date-object": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-              "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
               "bundled": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "bundled": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -40146,8 +34405,6 @@
             },
             "is-installed-globally": {
               "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
               "bundled": true,
               "requires": {
                 "global-dirs": "^0.1.0",
@@ -40156,20 +34413,14 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
               "bundled": true
             },
             "is-obj": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
               "bundled": true
             },
             "is-path-inside": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-              "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
               "bundled": true,
               "requires": {
                 "path-is-inside": "^1.0.1"
@@ -40177,14 +34428,10 @@
             },
             "is-redirect": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
               "bundled": true
             },
             "is-regex": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-              "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
               "bundled": true,
               "requires": {
                 "has": "^1.0.1"
@@ -40192,20 +34439,14 @@
             },
             "is-retry-allowed": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-              "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
               "bundled": true
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
               "bundled": true
             },
             "is-symbol": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-              "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
               "bundled": true,
               "requires": {
                 "has-symbols": "^1.0.0"
@@ -40213,63 +34454,43 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "bundled": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "bundled": true
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "bundled": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "bundled": true
             },
             "jsbn": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
               "bundled": true,
               "optional": true
             },
             "json-parse-better-errors": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
               "bundled": true
             },
             "json-schema": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-              "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
               "bundled": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "bundled": true
             },
             "jsonparse": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
               "bundled": true
             },
             "JSONStream": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-              "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
               "bundled": true,
               "requires": {
                 "jsonparse": "^1.2.0",
@@ -40278,8 +34499,6 @@
             },
             "jsprim": {
               "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-              "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
               "bundled": true,
               "requires": {
                 "assert-plus": "1.0.0",
@@ -40290,8 +34509,6 @@
             },
             "latest-version": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
               "bundled": true,
               "requires": {
                 "package-json": "^4.0.0"
@@ -40299,14 +34516,10 @@
             },
             "lazy-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
               "bundled": true
             },
             "libcipm": {
               "version": "4.0.8",
-              "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
-              "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
               "bundled": true,
               "requires": {
                 "bin-links": "^1.1.2",
@@ -40328,8 +34541,6 @@
             },
             "libnpm": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
-              "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
               "bundled": true,
               "requires": {
                 "bin-links": "^1.1.2",
@@ -40356,8 +34567,6 @@
             },
             "libnpmaccess": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
-              "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
               "bundled": true,
               "requires": {
                 "aproba": "^2.0.0",
@@ -40368,8 +34577,6 @@
             },
             "libnpmconfig": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-              "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
               "bundled": true,
               "requires": {
                 "figgy-pudding": "^3.5.1",
@@ -40379,8 +34586,6 @@
               "dependencies": {
                 "find-up": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                  "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                   "bundled": true,
                   "requires": {
                     "locate-path": "^3.0.0"
@@ -40388,8 +34593,6 @@
                 },
                 "locate-path": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                  "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                   "bundled": true,
                   "requires": {
                     "p-locate": "^3.0.0",
@@ -40398,8 +34601,6 @@
                 },
                 "p-limit": {
                   "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                  "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
                   "bundled": true,
                   "requires": {
                     "p-try": "^2.0.0"
@@ -40407,8 +34608,6 @@
                 },
                 "p-locate": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                  "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                   "bundled": true,
                   "requires": {
                     "p-limit": "^2.0.0"
@@ -40416,16 +34615,12 @@
                 },
                 "p-try": {
                   "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                  "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                   "bundled": true
                 }
               }
             },
             "libnpmhook": {
               "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
-              "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
               "bundled": true,
               "requires": {
                 "aproba": "^2.0.0",
@@ -40436,8 +34631,6 @@
             },
             "libnpmorg": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
-              "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
               "bundled": true,
               "requires": {
                 "aproba": "^2.0.0",
@@ -40448,8 +34641,6 @@
             },
             "libnpmpublish": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
-              "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
               "bundled": true,
               "requires": {
                 "aproba": "^2.0.0",
@@ -40465,8 +34656,6 @@
             },
             "libnpmsearch": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
-              "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
               "bundled": true,
               "requires": {
                 "figgy-pudding": "^3.5.1",
@@ -40476,8 +34665,6 @@
             },
             "libnpmteam": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
-              "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
               "bundled": true,
               "requires": {
                 "aproba": "^2.0.0",
@@ -40488,8 +34675,6 @@
             },
             "libnpx": {
               "version": "10.2.4",
-              "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
-              "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
               "bundled": true,
               "requires": {
                 "dotenv": "^5.0.1",
@@ -40504,8 +34689,6 @@
             },
             "lock-verify": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
-              "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
               "bundled": true,
               "requires": {
                 "npm-package-arg": "^6.1.0",
@@ -40514,8 +34697,6 @@
             },
             "lockfile": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-              "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
               "bundled": true,
               "requires": {
                 "signal-exit": "^3.0.2"
@@ -40523,14 +34704,10 @@
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "bundled": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "bundled": true,
               "requires": {
                 "lodash._createset": "~4.0.0",
@@ -40539,20 +34716,14 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "bundled": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "bundled": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "bundled": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
@@ -40560,62 +34731,42 @@
             },
             "lodash._createset": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
               "bundled": true
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "bundled": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
               "bundled": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "bundled": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "bundled": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "bundled": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "bundled": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "bundled": true
             },
             "lowercase-keys": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-              "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
               "bundled": true
             },
             "lru-cache": {
               "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
               "bundled": true,
               "requires": {
                 "yallist": "^3.0.2"
@@ -40623,8 +34774,6 @@
             },
             "make-dir": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
               "bundled": true,
               "requires": {
                 "pify": "^3.0.0"
@@ -40632,8 +34781,6 @@
             },
             "make-fetch-happen": {
               "version": "5.0.2",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
-              "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
               "bundled": true,
               "requires": {
                 "agentkeepalive": "^3.4.1",
@@ -40651,20 +34798,14 @@
             },
             "meant": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
-              "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
               "bundled": true
             },
             "mime-db": {
               "version": "1.35.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-              "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
               "bundled": true
             },
             "mime-types": {
               "version": "2.1.19",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-              "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
               "bundled": true,
               "requires": {
                 "mime-db": "~1.35.0"
@@ -40672,8 +34813,6 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "bundled": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -40681,14 +34820,10 @@
             },
             "minimist": {
               "version": "1.2.6",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-              "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
               "bundled": true
             },
             "minizlib": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-              "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
               "bundled": true,
               "requires": {
                 "minipass": "^2.9.0"
@@ -40696,8 +34831,6 @@
               "dependencies": {
                 "minipass": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                  "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
@@ -40708,8 +34841,6 @@
             },
             "mississippi": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-              "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
               "bundled": true,
               "requires": {
                 "concat-stream": "^1.5.0",
@@ -40726,8 +34857,6 @@
             },
             "mkdirp": {
               "version": "0.5.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-              "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
               "bundled": true,
               "requires": {
                 "minimist": "^1.2.5"
@@ -40735,16 +34864,12 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-                  "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
                   "bundled": true
                 }
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.1",
@@ -40757,28 +34882,20 @@
               "dependencies": {
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true
                 }
               }
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "bundled": true
             },
             "mute-stream": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
               "bundled": true
             },
             "node-fetch-npm": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-              "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
               "bundled": true,
               "requires": {
                 "encoding": "^0.1.11",
@@ -40788,8 +34905,6 @@
             },
             "node-gyp": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
-              "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
               "bundled": true,
               "requires": {
                 "env-paths": "^2.2.0",
@@ -40807,8 +34922,6 @@
             },
             "nopt": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-              "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
               "bundled": true,
               "requires": {
                 "abbrev": "1",
@@ -40817,8 +34930,6 @@
             },
             "normalize-package-data": {
               "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
               "bundled": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -40829,8 +34940,6 @@
               "dependencies": {
                 "resolve": {
                   "version": "1.10.0",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-                  "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
                   "bundled": true,
                   "requires": {
                     "path-parse": "^1.0.6"
@@ -40840,8 +34949,6 @@
             },
             "npm-audit-report": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
-              "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
               "bundled": true,
               "requires": {
                 "cli-table3": "^0.5.0",
@@ -40850,8 +34957,6 @@
             },
             "npm-bundled": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-              "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
               "bundled": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
@@ -40859,14 +34964,10 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "bundled": true
             },
             "npm-install-checks": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
-              "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
               "bundled": true,
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -40874,8 +34975,6 @@
             },
             "npm-lifecycle": {
               "version": "3.1.5",
-              "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
-              "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
               "bundled": true,
               "requires": {
                 "byline": "^5.0.0",
@@ -40890,20 +34989,14 @@
             },
             "npm-logical-tree": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-              "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
               "bundled": true
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-              "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
               "bundled": true
             },
             "npm-package-arg": {
               "version": "6.1.1",
-              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
-              "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
               "bundled": true,
               "requires": {
                 "hosted-git-info": "^2.7.1",
@@ -40914,8 +35007,6 @@
             },
             "npm-packlist": {
               "version": "1.4.8",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-              "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
               "bundled": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
@@ -40925,8 +35016,6 @@
             },
             "npm-pick-manifest": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
-              "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
               "bundled": true,
               "requires": {
                 "figgy-pudding": "^3.5.1",
@@ -40936,8 +35025,6 @@
             },
             "npm-profile": {
               "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
-              "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.2 || 2",
@@ -40947,8 +35034,6 @@
             },
             "npm-registry-fetch": {
               "version": "4.0.7",
-              "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
-              "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.1",
@@ -40962,16 +35047,12 @@
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.2.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
                   "bundled": true
                 }
               }
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
               "bundled": true,
               "requires": {
                 "path-key": "^2.0.0"
@@ -40979,14 +35060,10 @@
             },
             "npm-user-validate": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
-              "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
               "bundled": true
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "bundled": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -40997,32 +35074,22 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "bundled": true
             },
             "oauth-sign": {
               "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-              "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
               "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "bundled": true
             },
             "object-keys": {
               "version": "1.0.12",
-              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-              "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
               "bundled": true
             },
             "object.getownpropertydescriptors": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-              "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
               "bundled": true,
               "requires": {
                 "define-properties": "^1.1.2",
@@ -41031,8 +35098,6 @@
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "bundled": true,
               "requires": {
                 "wrappy": "1"
@@ -41040,26 +35105,18 @@
             },
             "opener": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-              "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
               "bundled": true
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "bundled": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "bundled": true
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "bundled": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -41068,14 +35125,10 @@
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
               "bundled": true
             },
             "package-json": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-              "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
               "bundled": true,
               "requires": {
                 "got": "^6.7.1",
@@ -41086,8 +35139,6 @@
             },
             "pacote": {
               "version": "9.5.12",
-              "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
-              "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.3",
@@ -41124,8 +35175,6 @@
               "dependencies": {
                 "minipass": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                  "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
@@ -41136,8 +35185,6 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "bundled": true,
               "requires": {
                 "cyclist": "~0.2.2",
@@ -41147,8 +35194,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -41162,8 +35207,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -41173,68 +35216,46 @@
             },
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "bundled": true
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "bundled": true
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "bundled": true
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
               "bundled": true
             },
             "path-parse": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-              "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
               "bundled": true
             },
             "performance-now": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
               "bundled": true
             },
             "pify": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "bundled": true
             },
             "prepend-http": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
               "bundled": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
               "bundled": true
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
               "bundled": true
             },
             "promise-retry": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "bundled": true,
               "requires": {
                 "err-code": "^1.0.0",
@@ -41243,16 +35264,12 @@
               "dependencies": {
                 "retry": {
                   "version": "0.10.1",
-                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
                   "bundled": true
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "bundled": true,
               "requires": {
                 "read": "1"
@@ -41260,14 +35277,10 @@
             },
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "bundled": true
             },
             "protoduck": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
-              "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
               "bundled": true,
               "requires": {
                 "genfun": "^5.0.0"
@@ -41275,26 +35288,18 @@
             },
             "prr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-              "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
               "bundled": true
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "bundled": true
             },
             "psl": {
               "version": "1.1.29",
-              "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-              "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
               "bundled": true
             },
             "pump": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-              "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
               "bundled": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -41303,8 +35308,6 @@
             },
             "pumpify": {
               "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-              "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
               "bundled": true,
               "requires": {
                 "duplexify": "^3.6.0",
@@ -41314,8 +35317,6 @@
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-                  "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                   "bundled": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -41326,26 +35327,18 @@
             },
             "punycode": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
               "bundled": true
             },
             "qrcode-terminal": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-              "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
               "bundled": true
             },
             "qs": {
               "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
               "bundled": true
             },
             "query-string": {
               "version": "6.8.2",
-              "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
-              "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
               "bundled": true,
               "requires": {
                 "decode-uri-component": "^0.2.0",
@@ -41355,14 +35348,10 @@
             },
             "qw": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-              "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
               "bundled": true
             },
             "rc": {
               "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "bundled": true,
               "requires": {
                 "deep-extend": "^0.6.0",
@@ -41373,8 +35362,6 @@
             },
             "read": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "bundled": true,
               "requires": {
                 "mute-stream": "~0.0.4"
@@ -41382,8 +35369,6 @@
             },
             "read-cmd-shim": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
-              "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
@@ -41391,8 +35376,6 @@
             },
             "read-installed": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "bundled": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -41406,8 +35389,6 @@
             },
             "read-package-json": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-              "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
               "bundled": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -41419,8 +35400,6 @@
             },
             "read-package-tree": {
               "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
-              "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
               "bundled": true,
               "requires": {
                 "read-package-json": "^2.0.0",
@@ -41430,8 +35409,6 @@
             },
             "readable-stream": {
               "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "bundled": true,
               "requires": {
                 "inherits": "^2.0.3",
@@ -41441,8 +35418,6 @@
             },
             "readdir-scoped-modules": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-              "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
               "bundled": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -41453,8 +35428,6 @@
             },
             "registry-auth-token": {
               "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-              "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
               "bundled": true,
               "requires": {
                 "rc": "^1.1.6",
@@ -41463,8 +35436,6 @@
             },
             "registry-url": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-              "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
               "bundled": true,
               "requires": {
                 "rc": "^1.0.1"
@@ -41472,8 +35443,6 @@
             },
             "request": {
               "version": "2.88.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-              "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
               "bundled": true,
               "requires": {
                 "aws-sign2": "~0.7.0",
@@ -41500,32 +35469,22 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
               "bundled": true
             },
             "require-main-filename": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-              "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
               "bundled": true
             },
             "resolve-from": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "bundled": true
             },
             "retry": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-              "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
               "bundled": true
             },
             "rimraf": {
               "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
               "bundled": true,
               "requires": {
                 "glob": "^7.1.3"
@@ -41533,8 +35492,6 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.1"
@@ -41542,34 +35499,24 @@
               "dependencies": {
                 "aproba": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                  "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                   "bundled": true
                 }
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "bundled": true
             },
             "semver": {
               "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "bundled": true
             },
             "semver-diff": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
               "bundled": true,
               "requires": {
                 "semver": "^5.0.3"
@@ -41577,14 +35524,10 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "bundled": true
             },
             "sha": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
-              "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
@@ -41592,8 +35535,6 @@
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "bundled": true,
               "requires": {
                 "shebang-regex": "^1.0.0"
@@ -41601,32 +35542,22 @@
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
               "bundled": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "bundled": true
             },
             "slide": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "bundled": true
             },
             "smart-buffer": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-              "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
               "bundled": true
             },
             "socks": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-              "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
               "bundled": true,
               "requires": {
                 "ip": "1.1.5",
@@ -41635,8 +35566,6 @@
             },
             "socks-proxy-agent": {
               "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-              "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
               "bundled": true,
               "requires": {
                 "agent-base": "~4.2.1",
@@ -41645,8 +35574,6 @@
               "dependencies": {
                 "agent-base": {
                   "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-                  "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
                   "bundled": true,
                   "requires": {
                     "es6-promisify": "^5.0.0"
@@ -41656,14 +35583,10 @@
             },
             "sorted-object": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "bundled": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "bundled": true,
               "requires": {
                 "from2": "^1.3.0",
@@ -41672,8 +35595,6 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "bundled": true,
                   "requires": {
                     "inherits": "~2.0.1",
@@ -41682,14 +35603,10 @@
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                   "bundled": true
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -41700,16 +35617,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "bundled": true
                 }
               }
             },
             "spdx-correct": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-              "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
               "bundled": true,
               "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -41718,14 +35631,10 @@
             },
             "spdx-exceptions": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-              "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
               "bundled": true
             },
             "spdx-expression-parse": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-              "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
               "bundled": true,
               "requires": {
                 "spdx-exceptions": "^2.1.0",
@@ -41734,20 +35643,14 @@
             },
             "spdx-license-ids": {
               "version": "3.0.5",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-              "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
               "bundled": true
             },
             "split-on-first": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-              "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
               "bundled": true
             },
             "sshpk": {
               "version": "1.14.2",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-              "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
               "bundled": true,
               "requires": {
                 "asn1": "~0.2.3",
@@ -41763,8 +35666,6 @@
             },
             "ssri": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-              "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
               "bundled": true,
               "requires": {
                 "figgy-pudding": "^3.5.1"
@@ -41772,8 +35673,6 @@
             },
             "stream-each": {
               "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-              "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
               "bundled": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -41782,8 +35681,6 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "bundled": true,
               "requires": {
                 "readable-stream": "^2.1.5",
@@ -41792,8 +35689,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -41807,8 +35702,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -41818,20 +35711,14 @@
             },
             "stream-shift": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-              "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
               "bundled": true
             },
             "strict-uri-encode": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
               "bundled": true
             },
             "string_decoder": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.2.0"
@@ -41839,16 +35726,12 @@
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-                  "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
                   "bundled": true
                 }
               }
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "bundled": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -41857,20 +35740,14 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                   "bundled": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "bundled": true
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                   "bundled": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
@@ -41880,14 +35757,10 @@
             },
             "stringify-package": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-              "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
               "bundled": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -41895,20 +35768,14 @@
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
               "bundled": true
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "bundled": true
             },
             "supports-color": {
               "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
               "bundled": true,
               "requires": {
                 "has-flag": "^3.0.0"
@@ -41916,8 +35783,6 @@
             },
             "tar": {
               "version": "4.4.19",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-              "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
               "bundled": true,
               "requires": {
                 "chownr": "^1.1.4",
@@ -41931,8 +35796,6 @@
               "dependencies": {
                 "minipass": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                  "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
@@ -41941,22 +35804,16 @@
                 },
                 "safe-buffer": {
                   "version": "5.2.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                  "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
                   "bundled": true
                 },
                 "yallist": {
                   "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                  "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                   "bundled": true
                 }
               }
             },
             "term-size": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-              "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
               "bundled": true,
               "requires": {
                 "execa": "^0.7.0"
@@ -41964,20 +35821,14 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "bundled": true
             },
             "through": {
               "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
               "bundled": true
             },
             "through2": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "bundled": true,
               "requires": {
                 "readable-stream": "^2.1.5",
@@ -41986,8 +35837,6 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.3.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                  "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                   "bundled": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -42001,8 +35850,6 @@
                 },
                 "string_decoder": {
                   "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                   "bundled": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -42012,20 +35859,14 @@
             },
             "timed-out": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
               "bundled": true
             },
             "tiny-relative-date": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-              "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
               "bundled": true
             },
             "tough-cookie": {
               "version": "2.4.3",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-              "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
               "bundled": true,
               "requires": {
                 "psl": "^1.1.24",
@@ -42034,8 +35875,6 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.0.1"
@@ -42043,33 +35882,23 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
               "bundled": true,
               "optional": true
             },
             "typedarray": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
               "bundled": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "bundled": true
             },
             "umask": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "bundled": true
             },
             "unique-filename": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-              "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
               "bundled": true,
               "requires": {
                 "unique-slug": "^2.0.0"
@@ -42077,8 +35906,6 @@
             },
             "unique-slug": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "bundled": true,
               "requires": {
                 "imurmurhash": "^0.1.4"
@@ -42086,8 +35913,6 @@
             },
             "unique-string": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-              "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
               "bundled": true,
               "requires": {
                 "crypto-random-string": "^1.0.0"
@@ -42095,20 +35920,14 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "bundled": true
             },
             "unzip-response": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
               "bundled": true
             },
             "update-notifier": {
               "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-              "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
               "bundled": true,
               "requires": {
                 "boxen": "^1.2.1",
@@ -42125,8 +35944,6 @@
             },
             "uri-js": {
               "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-              "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
               "bundled": true,
               "requires": {
                 "punycode": "^2.1.0"
@@ -42134,16 +35951,12 @@
               "dependencies": {
                 "punycode": {
                   "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                  "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
                   "bundled": true
                 }
               }
             },
             "url-parse-lax": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
               "bundled": true,
               "requires": {
                 "prepend-http": "^1.0.1"
@@ -42151,20 +35964,14 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "bundled": true
             },
             "util-extend": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
               "bundled": true
             },
             "util-promisify": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-              "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
               "bundled": true,
               "requires": {
                 "object.getownpropertydescriptors": "^2.0.3"
@@ -42172,14 +35979,10 @@
             },
             "uuid": {
               "version": "3.3.3",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-              "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
               "bundled": true
             },
             "validate-npm-package-license": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-              "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
               "bundled": true,
               "requires": {
                 "spdx-correct": "^3.0.0",
@@ -42188,8 +35991,6 @@
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "bundled": true,
               "requires": {
                 "builtins": "^1.0.3"
@@ -42197,8 +35998,6 @@
             },
             "verror": {
               "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
               "bundled": true,
               "requires": {
                 "assert-plus": "^1.0.0",
@@ -42208,8 +36007,6 @@
             },
             "wcwidth": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "bundled": true,
               "requires": {
                 "defaults": "^1.0.3"
@@ -42217,8 +36014,6 @@
             },
             "which": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
               "bundled": true,
               "requires": {
                 "isexe": "^2.0.0"
@@ -42226,14 +36021,10 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
               "bundled": true
             },
             "wide-align": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "bundled": true,
               "requires": {
                 "string-width": "^1.0.2"
@@ -42241,8 +36032,6 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "bundled": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -42254,8 +36043,6 @@
             },
             "widest-line": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-              "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
               "bundled": true,
               "requires": {
                 "string-width": "^2.1.1"
@@ -42263,8 +36050,6 @@
             },
             "worker-farm": {
               "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-              "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
               "bundled": true,
               "requires": {
                 "errno": "~0.1.7"
@@ -42272,8 +36057,6 @@
             },
             "wrap-ansi": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
               "bundled": true,
               "requires": {
                 "ansi-styles": "^3.2.0",
@@ -42283,20 +36066,14 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-                  "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
                   "bundled": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                  "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                   "bundled": true,
                   "requires": {
                     "emoji-regex": "^7.0.1",
@@ -42306,8 +36083,6 @@
                 },
                 "strip-ansi": {
                   "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                  "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                   "bundled": true,
                   "requires": {
                     "ansi-regex": "^4.1.0"
@@ -42317,14 +36092,10 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "bundled": true
             },
             "write-file-atomic": {
               "version": "2.4.3",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-              "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
               "bundled": true,
               "requires": {
                 "graceful-fs": "^4.1.11",
@@ -42334,32 +36105,22 @@
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
               "bundled": true
             },
             "xtend": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
               "bundled": true
             },
             "y18n": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-              "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
               "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "bundled": true
             },
             "yargs": {
               "version": "14.2.3",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-              "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
               "bundled": true,
               "requires": {
                 "cliui": "^5.0.0",
@@ -42377,14 +36138,10 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                   "bundled": true
                 },
                 "find-up": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                  "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                   "bundled": true,
                   "requires": {
                     "locate-path": "^3.0.0"
@@ -42392,14 +36149,10 @@
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                   "bundled": true
                 },
                 "locate-path": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                  "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                   "bundled": true,
                   "requires": {
                     "p-locate": "^3.0.0",
@@ -42408,8 +36161,6 @@
                 },
                 "p-limit": {
                   "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                  "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                   "bundled": true,
                   "requires": {
                     "p-try": "^2.0.0"
@@ -42417,8 +36168,6 @@
                 },
                 "p-locate": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                  "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                   "bundled": true,
                   "requires": {
                     "p-limit": "^2.0.0"
@@ -42426,14 +36175,10 @@
                 },
                 "p-try": {
                   "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                  "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                  "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                   "bundled": true,
                   "requires": {
                     "emoji-regex": "^7.0.1",
@@ -42443,8 +36188,6 @@
                 },
                 "strip-ansi": {
                   "version": "5.2.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                  "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                   "bundled": true,
                   "requires": {
                     "ansi-regex": "^4.1.0"
@@ -42454,8 +36197,6 @@
             },
             "yargs-parser": {
               "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
               "bundled": true,
               "requires": {
                 "camelcase": "^5.0.0",
@@ -42464,8 +36205,6 @@
               "dependencies": {
                 "camelcase": {
                   "version": "5.3.1",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                  "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                   "bundled": true
                 }
               }
@@ -44534,20 +38273,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "16.0.1",
         "mocha-junit-reporter": "^2.0.0",
         "sauce-testrunner-utils": "0.6.1",
         "saucelabs": "4.7.5",
         "testcafe": "1.19.0",
         "testcafe-browser-provider-ios": "0.5.0",
         "testcafe-reporter-sauce-json": "0.5.0",
-        "typescript": "^3.9.7",
+        "typescript": "4.7.4",
         "xml-js": "1.6.11"
       },
       "bin": {
@@ -5874,6 +5875,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/download": {
@@ -20448,6 +20457,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/testcafe/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -20757,9 +20778,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26275,6 +26296,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "download": {
       "version": "7.1.0",
@@ -37062,6 +37088,11 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
         }
       }
     },
@@ -37638,9 +37669,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "testcafe"
   ],
   "dependencies": {
+    "dotenv": "16.0.1",
     "mocha-junit-reporter": "^2.0.0",
     "sauce-testrunner-utils": "0.6.1",
     "saucelabs": "4.7.5",
     "testcafe": "1.19.0",
     "testcafe-browser-provider-ios": "0.5.0",
     "testcafe-reporter-sauce-json": "0.5.0",
-    "typescript": "^3.9.7",
+    "typescript": "4.7.4",
     "xml-js": "1.6.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,18 +16,14 @@
     "testcafe"
   ],
   "dependencies": {
-    "glob": "^7.1.6",
-    "js-yaml": "^3.14.0",
     "mocha-junit-reporter": "^2.0.0",
-    "npm": "^7.24.2",
     "sauce-testrunner-utils": "0.6.1",
     "saucelabs": "4.7.5",
     "testcafe": "1.19.0",
     "testcafe-browser-provider-ios": "0.5.0",
     "testcafe-reporter-sauce-json": "0.5.0",
     "typescript": "^3.9.7",
-    "xml-js": "1.6.11",
-    "xml2js": "^0.4.23"
+    "xml-js": "1.6.11"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
@@ -43,8 +39,7 @@
     "jest": "^26.4.2",
     "mocha": "^8.1.3",
     "release-it": "^14.4.1",
-    "saucectl": "0.97.0",
-    "typescript": "^3.9.7"
+    "saucectl": "0.97.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Adding some packages that may be useful at runtime. There are testcafe maintained packages for framework specific selectors (e.g. https://github.com/DevExpress/testcafe-react-selectors) that I'm on the fence about adding. I think they are reasonably popular (sauce uses them), but there are no instances of them in our usage info.

### Added
* dotenv

### Upgraded
* typescript

### Removed
* glob
* js-yaml
* npm
* xml2js