### PR TITLE
Update testcafe to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@saucelabs/testcomposer": "^0.1.0",
-        "dotenv": "16.0.2",
-        "mocha-junit-reporter": "^2.0.0",
+        "dotenv": "16.0.3",
+        "mocha-junit-reporter": "^2.1.0",
         "sauce-testrunner-utils": "0.6.1",
-        "testcafe": "2.0.0",
+        "testcafe": "2.0.1",
         "testcafe-browser-provider-ios": "0.5.0",
         "testcafe-reporter-sauce-json": "0.5.1",
-        "typescript": "4.8.2",
+        "typescript": "4.8.4",
         "xml-js": "1.6.11",
-        "yargs": "17.5.1"
+        "yargs": "17.6.0"
       },
       "bin": {
         "sauce-testcafe-runner": "bin/testcafe"
@@ -4804,9 +4804,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
       }
@@ -6381,6 +6381,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -6660,17 +6665,17 @@
       }
     },
     "node_modules/io-ts": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.18.tgz",
-      "integrity": "sha512-3JxUUzRtPQPs5sOwB7pW0+Xb54nOzqA6M1sRB1hwgsRmkWMeGTjtOrCynGTJhIj+mBLUj2S37DAq2+BrPh9kTQ==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.19.tgz",
+      "integrity": "sha512-ED0GQwvKRr5C2jqOOJCkuJW2clnbzqFexQ8V7Qsb+VB36S1Mk/OKH7k0FjSe4mjKy9qBRA3OqgVGyFMUEKIubw==",
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
     },
     "node_modules/io-ts-types": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
-      "integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.19.tgz",
+      "integrity": "sha512-kQOYYDZG5vKre+INIDZbLeDJe+oM+4zLpUkjXyTMyUfoCpjJNyi29ZLkuEAwcPufaYo3yu/BsemZtbdD+NtRfQ==",
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "io-ts": "^2.0.0",
@@ -8943,9 +8948,9 @@
       }
     },
     "node_modules/mocha-junit-reporter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.2.tgz",
-      "integrity": "sha512-vYwWq5hh3v1lG0gdQCBxwNipBfvDiAM1PHroQRNp96+2l72e9wEUTw+mzoK+O0SudgfQ7WvTQZ9Nh3qkAYAjfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.1.0.tgz",
+      "integrity": "sha512-Zhz1J+XqJUaAOuSFtHgi2+b+W3rP1SZtaU3HHNNp1iEKMSeoC1/EQUVkGknkLNOBxJhXJ4xLgOr8TbYAZOkUIw==",
       "dependencies": {
         "debug": "^2.2.0",
         "md5": "^2.1.0",
@@ -15547,9 +15552,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.0.0.tgz",
-      "integrity": "sha512-8VZTGBnEQUzFRAFg67vETGFB1DyE3Q/Vmx3BpHz3r6PosRAoTOUNBJiLUAe9mpbs4cjoF5kzqSXbCbdF4tL1UQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.0.1.tgz",
+      "integrity": "sha512-ICGHFBQTNRKiaS4mAkh2Y6ZR/iVi/TqKxoQNQHnIslK1++HNlb8bsFC7AHsqiAN3cMXrsa8qPawJYN4zj0FqMQ==",
       "dependencies": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -15596,6 +15601,7 @@
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
         "graphlib": "^2.1.5",
+        "http-status-codes": "^2.2.0",
         "humanize-duration": "^3.25.0",
         "import-lazy": "^3.1.0",
         "indent-string": "^1.2.2",
@@ -15630,9 +15636,9 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.7.3",
+        "testcafe-hammerhead": "24.7.4",
         "testcafe-legacy-api": "5.1.5",
-        "testcafe-reporter-dashboard": "1.0.0-rc.3",
+        "testcafe-reporter-dashboard": "^0.2.7-rc.1",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -15843,9 +15849,9 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "24.7.3",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.7.3.tgz",
-      "integrity": "sha512-3VfGuFLoh9selCk88zqDG5KxN2A73nBzYRaymQHlh3fFcaQ6XH1gkOGEn0MWaly+aDcG2snBFlK82n1i/vz2jA==",
+      "version": "24.7.4",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.7.4.tgz",
+      "integrity": "sha512-0fWktWkn6QcKGfXobu297EMKyTrDEFFyK+2qEUv9ldG9PMaZ6ZmXicckidTWtIao+ACFL8KlFC5DzXH2MZVhcg==",
       "dependencies": {
         "acorn-hammerhead": "0.6.1",
         "asar": "^2.0.1",
@@ -16030,12 +16036,12 @@
       }
     },
     "node_modules/testcafe-reporter-dashboard": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.3.tgz",
-      "integrity": "sha512-F4gphX9/KlZzEz26I9LwUw7DKdKFQEpsU4Pr04ssBOJCyZh4ST7kuOyB+JMqr4iJfE9zu6+g6aaXumM+ad61JA==",
+      "version": "0.2.7-rc.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.7-rc.1.tgz",
+      "integrity": "sha512-Cc8wk71p4WlRcNu1bYsTm7dB0JDCCzf1NDuOTua1caJ0cG7Ov6eanE/e1dpzAnBOCgz/uEM50GJhuE4iBBxykw==",
       "dependencies": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.12.1",
+        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -16553,9 +16559,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17149,11 +17155,11 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -17215,6 +17221,19 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
@@ -20808,9 +20827,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "duplexer3": {
       "version": "0.1.5",
@@ -22022,6 +22041,11 @@
         "debug": "4"
       }
     },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -22219,15 +22243,15 @@
       "dev": true
     },
     "io-ts": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.18.tgz",
-      "integrity": "sha512-3JxUUzRtPQPs5sOwB7pW0+Xb54nOzqA6M1sRB1hwgsRmkWMeGTjtOrCynGTJhIj+mBLUj2S37DAq2+BrPh9kTQ==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.19.tgz",
+      "integrity": "sha512-ED0GQwvKRr5C2jqOOJCkuJW2clnbzqFexQ8V7Qsb+VB36S1Mk/OKH7k0FjSe4mjKy9qBRA3OqgVGyFMUEKIubw==",
       "requires": {}
     },
     "io-ts-types": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
-      "integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.19.tgz",
+      "integrity": "sha512-kQOYYDZG5vKre+INIDZbLeDJe+oM+4zLpUkjXyTMyUfoCpjJNyi29ZLkuEAwcPufaYo3yu/BsemZtbdD+NtRfQ==",
       "requires": {}
     },
     "ip": {
@@ -24138,9 +24162,9 @@
       }
     },
     "mocha-junit-reporter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.2.tgz",
-      "integrity": "sha512-vYwWq5hh3v1lG0gdQCBxwNipBfvDiAM1PHroQRNp96+2l72e9wEUTw+mzoK+O0SudgfQ7WvTQZ9Nh3qkAYAjfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.1.0.tgz",
+      "integrity": "sha512-Zhz1J+XqJUaAOuSFtHgi2+b+W3rP1SZtaU3HHNNp1iEKMSeoC1/EQUVkGknkLNOBxJhXJ4xLgOr8TbYAZOkUIw==",
       "requires": {
         "debug": "^2.2.0",
         "md5": "^2.1.0",
@@ -28904,9 +28928,9 @@
       }
     },
     "testcafe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.0.0.tgz",
-      "integrity": "sha512-8VZTGBnEQUzFRAFg67vETGFB1DyE3Q/Vmx3BpHz3r6PosRAoTOUNBJiLUAe9mpbs4cjoF5kzqSXbCbdF4tL1UQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.0.1.tgz",
+      "integrity": "sha512-ICGHFBQTNRKiaS4mAkh2Y6ZR/iVi/TqKxoQNQHnIslK1++HNlb8bsFC7AHsqiAN3cMXrsa8qPawJYN4zj0FqMQ==",
       "requires": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -28953,6 +28977,7 @@
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
         "graphlib": "^2.1.5",
+        "http-status-codes": "^2.2.0",
         "humanize-duration": "^3.25.0",
         "import-lazy": "^3.1.0",
         "indent-string": "^1.2.2",
@@ -28987,9 +29012,9 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.7.3",
+        "testcafe-hammerhead": "24.7.4",
         "testcafe-legacy-api": "5.1.5",
-        "testcafe-reporter-dashboard": "1.0.0-rc.3",
+        "testcafe-reporter-dashboard": "^0.2.7-rc.1",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -29305,9 +29330,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.7.3",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.7.3.tgz",
-      "integrity": "sha512-3VfGuFLoh9selCk88zqDG5KxN2A73nBzYRaymQHlh3fFcaQ6XH1gkOGEn0MWaly+aDcG2snBFlK82n1i/vz2jA==",
+      "version": "24.7.4",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.7.4.tgz",
+      "integrity": "sha512-0fWktWkn6QcKGfXobu297EMKyTrDEFFyK+2qEUv9ldG9PMaZ6ZmXicckidTWtIao+ACFL8KlFC5DzXH2MZVhcg==",
       "requires": {
         "acorn-hammerhead": "0.6.1",
         "asar": "^2.0.1",
@@ -29470,12 +29495,12 @@
       }
     },
     "testcafe-reporter-dashboard": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.3.tgz",
-      "integrity": "sha512-F4gphX9/KlZzEz26I9LwUw7DKdKFQEpsU4Pr04ssBOJCyZh4ST7kuOyB+JMqr4iJfE9zu6+g6aaXumM+ad61JA==",
+      "version": "0.2.7-rc.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.7-rc.1.tgz",
+      "integrity": "sha512-Cc8wk71p4WlRcNu1bYsTm7dB0JDCCzf1NDuOTua1caJ0cG7Ov6eanE/e1dpzAnBOCgz/uEM50GJhuE4iBBxykw==",
       "requires": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.12.1",
+        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -29724,9 +29749,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -30161,11 +30186,11 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -30174,6 +30199,16 @@
         "yargs-parser": "^21.0.0"
       },
       "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
         "yargs-parser": {
           "version": "21.1.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   ],
   "dependencies": {
     "@saucelabs/testcomposer": "^0.1.0",
-    "dotenv": "16.0.2",
-    "mocha-junit-reporter": "^2.0.0",
+    "dotenv": "16.0.3",
+    "mocha-junit-reporter": "^2.1.0",
     "sauce-testrunner-utils": "0.6.1",
-    "testcafe": "2.0.0",
+    "testcafe": "2.0.1",
     "testcafe-browser-provider-ios": "0.5.0",
     "testcafe-reporter-sauce-json": "0.5.1",
-    "typescript": "4.8.2",
+    "typescript": "4.8.4",
     "xml-js": "1.6.11",
-    "yargs": "17.5.1"
+    "yargs": "17.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",


### PR DESCRIPTION
Maintenance update of testcafe.
Includes additional updates of runtime dependencies.