### PR TITLE
[DEVX-2069] bump to testcafe@2.2.0 + deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4316,7 +4316,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -4325,8 +4324,7 @@
     "node_modules/config-chain/node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/configstore": {
       "version": "6.0.0",
@@ -8162,9 +8160,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -9016,9 +9014,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "6.14.17",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.17.tgz",
-      "integrity": "sha512-CxEDn1ydVRPDl4tHrlnq+WevYAhv4GF2AEHzJKQ4prZDZ96IS3Uo6t0Sy6O9kB6XzqkI+J00WfYCqqk0p6IJ1Q==",
+      "version": "6.14.18",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.18.tgz",
+      "integrity": "sha512-p3SjqSchSuNQUqbJBgwdv0L3O6bKkaSfQrQzJsskNpNKLg0g37c5xTXFV0SqTlX9GWvoGxBELVJMRWq0J8oaLA==",
       "bundleDependencies": [
         "abbrev",
         "ansicolors",
@@ -9151,9 +9149,9 @@
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
         "bin-links": "^1.1.8",
-        "bluebird": "^3.5.5",
+        "bluebird": "^3.7.2",
         "byte-size": "^5.0.1",
-        "cacache": "^12.0.3",
+        "cacache": "^12.0.4",
         "call-limit": "^1.1.1",
         "chownr": "^1.1.4",
         "ci-info": "^2.0.0",
@@ -9161,19 +9159,19 @@
         "cli-table3": "^0.5.1",
         "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
-        "config-chain": "^1.1.12",
+        "config-chain": "^1.1.13",
         "debuglog": "*",
         "detect-indent": "~5.0.0",
         "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
+        "dezalgo": "^1.0.4",
         "editor": "~1.0.0",
-        "figgy-pudding": "^3.5.1",
+        "figgy-pudding": "^3.5.2",
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.3.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.10",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.8.9",
         "iferr": "^1.0.2",
@@ -9183,7 +9181,7 @@
         "inherits": "^2.0.4",
         "ini": "^1.3.8",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^3.0.0",
+        "is-cidr": "^3.1.1",
         "json-parse-better-errors": "^1.0.2",
         "JSONStream": "^1.3.5",
         "lazy-property": "~1.0.0",
@@ -9195,7 +9193,7 @@
         "libnpmsearch": "^2.0.2",
         "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.4",
-        "lock-verify": "^2.1.0",
+        "lock-verify": "^2.2.2",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -9209,11 +9207,11 @@
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
         "lru-cache": "^5.1.1",
-        "meant": "^1.0.2",
+        "meant": "^1.0.3",
         "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.5",
+        "mkdirp": "^0.5.6",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.1.0",
+        "node-gyp": "^5.1.1",
         "nopt": "^4.0.3",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.3",
@@ -9234,19 +9232,19 @@
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.2",
-        "qw": "~1.0.1",
+        "query-string": "^6.14.1",
+        "qw": "^1.0.2",
         "read": "~1.0.7",
         "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.1",
+        "read-package-json": "^2.1.2",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.6.0",
         "readdir-scoped-modules": "^1.1.0",
-        "request": "^2.88.0",
+        "request": "^2.88.2",
         "retry": "^0.12.0",
         "rimraf": "^2.7.1",
-        "safe-buffer": "^5.1.2",
+        "safe-buffer": "^5.2.1",
         "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
@@ -9262,7 +9260,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.3",
+        "uuid": "^3.4.0",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -9286,6 +9284,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/@iarna/cli": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.2",
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -9385,6 +9392,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -9393,13 +9405,18 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/asn1": {
-      "version": "0.2.4",
+      "version": "0.2.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9428,12 +9445,12 @@
       }
     },
     "node_modules/npm/node_modules/aws4": {
-      "version": "1.8.0",
+      "version": "1.11.0",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
     },
@@ -9441,7 +9458,6 @@
       "version": "1.0.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -9460,7 +9476,7 @@
       }
     },
     "node_modules/npm/node_modules/bluebird": {
-      "version": "3.5.5",
+      "version": "3.7.2",
       "inBundle": true,
       "license": "MIT"
     },
@@ -9517,7 +9533,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "12.0.3",
+      "version": "12.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9740,7 +9756,7 @@
       }
     },
     "node_modules/npm/node_modules/combined-stream": {
-      "version": "1.0.6",
+      "version": "1.0.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9783,6 +9799,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -9791,9 +9812,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/npm/node_modules/config-chain": {
-      "version": "1.1.12",
+    "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
       "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/config-chain": {
+      "version": "1.1.13",
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -9936,7 +9963,7 @@
       }
     },
     "node_modules/npm/node_modules/decode-uri-component": {
-      "version": "0.2.0",
+      "version": "0.2.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10000,7 +10027,7 @@
       }
     },
     "node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10057,6 +10084,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/duplexify/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -10065,11 +10097,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/npm/node_modules/duplexify/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -10102,7 +10138,7 @@
       }
     },
     "node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10218,9 +10254,17 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/figgy-pudding": {
-      "version": "3.5.1",
+      "version": "3.5.2",
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/filter-obj": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm/node_modules/find-npm-prefix": {
       "version": "1.0.2",
@@ -10250,6 +10294,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -10257,6 +10306,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
@@ -10267,12 +10321,12 @@
       }
     },
     "node_modules/npm/node_modules/form-data": {
-      "version": "2.3.2",
+      "version": "2.3.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -10302,6 +10356,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/from2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -10309,6 +10368,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/from2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "1.2.7",
@@ -10367,6 +10431,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -10374,6 +10443,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -10479,14 +10553,14 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "7.1.6",
+      "version": "7.2.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -10495,6 +10569,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/npm/node_modules/global-dirs": {
@@ -10538,7 +10623,7 @@
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.4",
+      "version": "4.2.10",
       "inBundle": true,
       "license": "ISC"
     },
@@ -10796,7 +10881,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "3.0.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10933,11 +11018,15 @@
     "node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-better-errors": {
       "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT"
     },
@@ -11205,12 +11294,16 @@
       }
     },
     "node_modules/npm/node_modules/lock-verify": {
-      "version": "2.1.0",
+      "version": "2.2.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@iarna/cli": "^2.1.0",
         "npm-package-arg": "^6.1.0",
         "semver": "^5.4.1"
+      },
+      "bin": {
+        "lock-verify": "cli.js"
       }
     },
     "node_modules/npm/node_modules/lockfile": {
@@ -11339,7 +11432,7 @@
       }
     },
     "node_modules/npm/node_modules/meant": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -11363,7 +11456,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11416,20 +11509,15 @@
       }
     },
     "node_modules/npm/node_modules/mkdirp": {
-      "version": "0.5.5",
+      "version": "0.5.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
-      "version": "1.2.6",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -11473,7 +11561,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "5.1.0",
+      "version": "5.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11860,6 +11948,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -11867,6 +11960,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/path-exists": {
       "version": "3.0.0",
@@ -11985,7 +12083,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/psl": {
-      "version": "1.1.29",
+      "version": "1.9.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -12019,7 +12117,6 @@
     },
     "node_modules/npm/node_modules/punycode": {
       "version": "1.4.1",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -12030,7 +12127,7 @@
       }
     },
     "node_modules/npm/node_modules/qs": {
-      "version": "6.5.2",
+      "version": "6.5.3",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -12038,20 +12135,24 @@
       }
     },
     "node_modules/npm/node_modules/query-string": {
-      "version": "6.8.2",
+      "version": "6.14.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/qw": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "inBundle": true,
       "license": "ISC"
     },
@@ -12105,17 +12206,14 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.1",
-        "json-parse-better-errors": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.0",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.2"
       }
     },
     "node_modules/npm/node_modules/read-package-tree": {
@@ -12173,7 +12271,8 @@
       }
     },
     "node_modules/npm/node_modules/request": {
-      "version": "2.88.0",
+      "version": "2.88.2",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12184,7 +12283,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -12194,12 +12293,12 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 6"
       }
     },
     "node_modules/npm/node_modules/require-directory": {
@@ -12256,7 +12355,21 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -12455,15 +12568,19 @@
       }
     },
     "node_modules/npm/node_modules/sshpk": {
-      "version": "1.14.2",
+      "version": "1.17.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "safer-buffer": "^2.0.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "bin": {
         "sshpk-conv": "bin/sshpk-conv",
@@ -12472,12 +12589,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "optionalDependencies": {
-        "bcrypt-pbkdf": "^1.0.0",
-        "ecc-jsbn": "~0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
       }
     },
     "node_modules/npm/node_modules/ssri": {
@@ -12520,6 +12631,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -12527,6 +12643,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/stream-shift": {
       "version": "1.0.0",
@@ -12730,6 +12851,11 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/npm/node_modules/through2/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
       "inBundle": true,
@@ -12737,6 +12863,11 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/npm/node_modules/through2/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/timed-out": {
       "version": "4.0.1",
@@ -12752,15 +12883,23 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tough-cookie": {
-      "version": "2.4.3",
+      "version": "2.5.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/npm/node_modules/tough-cookie/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/npm/node_modules/tunnel-agent": {
@@ -12777,8 +12916,7 @@
     "node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
       "inBundle": true,
-      "license": "Unlicense",
-      "optional": true
+      "license": "Unlicense"
     },
     "node_modules/npm/node_modules/typedarray": {
       "version": "0.0.6",
@@ -12862,7 +13000,7 @@
       }
     },
     "node_modules/npm/node_modules/uri-js": {
-      "version": "4.4.0",
+      "version": "4.4.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12907,7 +13045,8 @@
       }
     },
     "node_modules/npm/node_modules/uuid": {
-      "version": "3.3.3",
+      "version": "3.4.0",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -13965,8 +14104,7 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
     "node_modules/protocols": {
       "version": "2.0.1",
@@ -16155,9 +16293,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -20126,7 +20264,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -20135,8 +20272,7 @@
         "ini": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-          "dev": true
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         }
       }
     },
@@ -22981,9 +23117,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -23609,9 +23745,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.14.17",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.17.tgz",
-      "integrity": "sha512-CxEDn1ydVRPDl4tHrlnq+WevYAhv4GF2AEHzJKQ4prZDZ96IS3Uo6t0Sy6O9kB6XzqkI+J00WfYCqqk0p6IJ1Q==",
+      "version": "6.14.18",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.18.tgz",
+      "integrity": "sha512-p3SjqSchSuNQUqbJBgwdv0L3O6bKkaSfQrQzJsskNpNKLg0g37c5xTXFV0SqTlX9GWvoGxBELVJMRWq0J8oaLA==",
       "requires": {
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
@@ -23619,9 +23755,9 @@
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
         "bin-links": "^1.1.8",
-        "bluebird": "^3.5.5",
+        "bluebird": "^3.7.2",
         "byte-size": "^5.0.1",
-        "cacache": "^12.0.3",
+        "cacache": "^12.0.4",
         "call-limit": "^1.1.1",
         "chownr": "^1.1.4",
         "ci-info": "^2.0.0",
@@ -23629,19 +23765,19 @@
         "cli-table3": "^0.5.1",
         "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
-        "config-chain": "^1.1.12",
+        "config-chain": "^1.1.13",
         "debuglog": "*",
         "detect-indent": "~5.0.0",
         "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
+        "dezalgo": "^1.0.4",
         "editor": "~1.0.0",
-        "figgy-pudding": "^3.5.1",
+        "figgy-pudding": "^3.5.2",
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.3.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.10",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.8.9",
         "iferr": "^1.0.2",
@@ -23651,7 +23787,7 @@
         "inherits": "^2.0.4",
         "ini": "^1.3.8",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^3.0.0",
+        "is-cidr": "^3.1.1",
         "json-parse-better-errors": "^1.0.2",
         "JSONStream": "^1.3.5",
         "lazy-property": "~1.0.0",
@@ -23663,7 +23799,7 @@
         "libnpmsearch": "^2.0.2",
         "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.4",
-        "lock-verify": "^2.1.0",
+        "lock-verify": "^2.2.2",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -23677,11 +23813,11 @@
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
         "lru-cache": "^5.1.1",
-        "meant": "^1.0.2",
+        "meant": "^1.0.3",
         "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.5",
+        "mkdirp": "^0.5.6",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.1.0",
+        "node-gyp": "^5.1.1",
         "nopt": "^4.0.3",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.3",
@@ -23702,19 +23838,19 @@
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.2",
-        "qw": "~1.0.1",
+        "query-string": "^6.14.1",
+        "qw": "^1.0.2",
         "read": "~1.0.7",
         "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.1",
+        "read-package-json": "^2.1.2",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.6.0",
         "readdir-scoped-modules": "^1.1.0",
-        "request": "^2.88.0",
+        "request": "^2.88.2",
         "retry": "^0.12.0",
         "rimraf": "^2.7.1",
-        "safe-buffer": "^5.1.2",
+        "safe-buffer": "^5.2.1",
         "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
@@ -23730,7 +23866,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.3",
+        "uuid": "^3.4.0",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -23738,6 +23874,14 @@
         "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
+        "@iarna/cli": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.2",
+            "signal-exit": "^3.0.2"
+          }
+        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -23809,6 +23953,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -23816,6 +23966,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -23825,7 +23981,7 @@
           "bundled": true
         },
         "asn1": {
-          "version": "0.2.4",
+          "version": "0.2.6",
           "bundled": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -23844,17 +24000,16 @@
           "bundled": true
         },
         "aws4": {
-          "version": "1.8.0",
+          "version": "1.11.0",
           "bundled": true
         },
         "balanced-match": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
@@ -23872,7 +24027,7 @@
           }
         },
         "bluebird": {
-          "version": "3.5.5",
+          "version": "3.7.2",
           "bundled": true
         },
         "boxen": {
@@ -23913,7 +24068,7 @@
           "bundled": true
         },
         "cacache": {
-          "version": "12.0.3",
+          "version": "12.0.4",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -24070,7 +24225,7 @@
           }
         },
         "combined-stream": {
-          "version": "1.0.6",
+          "version": "1.0.8",
           "bundled": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -24101,6 +24256,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -24108,12 +24269,18 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
         },
         "config-chain": {
-          "version": "1.1.12",
+          "version": "1.1.13",
           "bundled": true,
           "requires": {
             "ini": "^1.3.4",
@@ -24229,7 +24396,7 @@
           "bundled": true
         },
         "decode-uri-component": {
-          "version": "0.2.0",
+          "version": "0.2.2",
           "bundled": true
         },
         "deep-extend": {
@@ -24267,7 +24434,7 @@
           "bundled": true
         },
         "dezalgo": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "requires": {
             "asap": "^2.0.0",
@@ -24310,6 +24477,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -24317,6 +24490,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -24324,7 +24503,6 @@
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -24353,7 +24531,7 @@
           }
         },
         "env-paths": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true
         },
         "err-code": {
@@ -24434,7 +24612,11 @@
           "bundled": true
         },
         "figgy-pudding": {
-          "version": "3.5.1",
+          "version": "3.5.2",
+          "bundled": true
+        },
+        "filter-obj": {
+          "version": "1.1.0",
           "bundled": true
         },
         "find-npm-prefix": {
@@ -24460,6 +24642,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -24467,6 +24655,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -24476,11 +24670,11 @@
           "bundled": true
         },
         "form-data": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "bundled": true,
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "1.0.6",
+            "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         },
@@ -24503,6 +24697,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -24510,6 +24710,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -24565,6 +24771,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -24572,6 +24784,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -24663,15 +24881,24 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
+          "version": "7.2.3",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "global-dirs": {
@@ -24705,7 +24932,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
+          "version": "4.2.10",
           "bundled": true
         },
         "har-schema": {
@@ -24885,7 +25112,7 @@
           }
         },
         "is-cidr": {
-          "version": "3.0.0",
+          "version": "3.1.1",
           "bundled": true,
           "requires": {
             "cidr-regex": "^2.0.10"
@@ -24969,11 +25196,14 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
           "bundled": true
         },
         "json-schema": {
@@ -25187,9 +25417,10 @@
           }
         },
         "lock-verify": {
-          "version": "2.1.0",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
+            "@iarna/cli": "^2.1.0",
             "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
@@ -25296,7 +25527,7 @@
           }
         },
         "meant": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true
         },
         "mime-db": {
@@ -25311,7 +25542,7 @@
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -25355,16 +25586,10 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.5",
+          "version": "0.5.6",
           "bundled": true,
           "requires": {
-            "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.6",
-              "bundled": true
-            }
+            "minimist": "^1.2.6"
           }
         },
         "move-concurrently": {
@@ -25403,7 +25628,7 @@
           }
         },
         "node-gyp": {
-          "version": "5.1.0",
+          "version": "5.1.1",
           "bundled": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -25702,6 +25927,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -25709,6 +25940,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -25794,7 +26031,7 @@
           "bundled": true
         },
         "psl": {
-          "version": "1.1.29",
+          "version": "1.9.0",
           "bundled": true
         },
         "pump": {
@@ -25825,28 +26062,28 @@
           }
         },
         "punycode": {
-          "version": "1.4.1",
-          "bundled": true
+          "version": "1.4.1"
         },
         "qrcode-terminal": {
           "version": "0.12.0",
           "bundled": true
         },
         "qs": {
-          "version": "6.5.2",
+          "version": "6.5.3",
           "bundled": true
         },
         "query-string": {
-          "version": "6.8.2",
+          "version": "6.14.1",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "filter-obj": "^1.1.0",
             "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
         "qw": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true
         },
         "rc": {
@@ -25887,12 +26124,11 @@
           }
         },
         "read-package-json": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "requires": {
             "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "normalize-package-data": "^2.0.0",
             "npm-normalize-package-bin": "^1.0.0"
           }
@@ -25941,7 +26177,7 @@
           }
         },
         "request": {
-          "version": "2.88.0",
+          "version": "2.88.2",
           "bundled": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -25951,7 +26187,7 @@
             "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
             "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
+            "har-validator": "~5.1.3",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
@@ -25961,7 +26197,7 @@
             "performance-now": "^2.1.0",
             "qs": "~6.5.2",
             "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
+            "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
           }
@@ -26003,7 +26239,7 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true
         },
         "safer-buffer": {
@@ -26149,7 +26385,7 @@
           "bundled": true
         },
         "sshpk": {
-          "version": "1.14.2",
+          "version": "1.17.0",
           "bundled": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -26197,6 +26433,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -26204,6 +26446,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -26345,6 +26593,12 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             },
             "string_decoder": {
@@ -26352,6 +26606,12 @@
               "bundled": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
             }
           }
@@ -26365,11 +26625,17 @@
           "bundled": true
         },
         "tough-cookie": {
-          "version": "2.4.3",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
           }
         },
         "tunnel-agent": {
@@ -26381,8 +26647,7 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "typedarray": {
           "version": "0.0.6",
@@ -26442,7 +26707,7 @@
           }
         },
         "uri-js": {
-          "version": "4.4.0",
+          "version": "4.4.1",
           "bundled": true,
           "requires": {
             "punycode": "^2.1.0"
@@ -26477,7 +26742,7 @@
           }
         },
         "uuid": {
-          "version": "3.3.3",
+          "version": "3.4.0",
           "bundled": true
         },
         "validate-npm-package-license": {
@@ -27236,8 +27501,7 @@
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
     },
     "protocols": {
       "version": "2.0.1",
@@ -28914,9 +29178,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "dotenv": "16.0.3",
         "mocha-junit-reporter": "^2.2.0",
         "sauce-testrunner-utils": "0.6.1",
-        "testcafe": "2.1.0",
+        "testcafe": "2.2.0",
         "testcafe-browser-provider-ios": "0.5.0",
-        "testcafe-reporter-sauce-json": "0.6.0",
+        "testcafe-reporter-sauce-json": "0.7.0",
         "typescript": "4.9.3",
         "xml-js": "1.6.11",
         "yargs": "17.6.2"
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/chrome-remote-interface": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.30.1.tgz",
-      "integrity": "sha512-emKaqCjYAgrT35nm6PvTUKJ++2NX9qAmrcNRPRGyryG9Kc7wlkvO0bmvEdNMrr8Bih2e149WctJZFzUiM1UNwg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz",
+      "integrity": "sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==",
       "dependencies": {
         "commander": "2.11.x",
         "ws": "^7.2.0"
@@ -15299,9 +15299,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.1.0.tgz",
-      "integrity": "sha512-mfF9UX2U9RyjNfuviaOf/MYEQA7uGxe0n+VXJzdPMqpPjvILe/LrAopyxjkmW5MllZAGW0/tmwOy9xRZl50l7A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.2.0.tgz",
+      "integrity": "sha512-ipZTM9lKQU9qM+Dv3Vobm02TrRFFJmfbkwiBJjpYh0YG18/l96Q/RX5D8KmuNDi3EmbJRLIWRkXIJ40AwUJnUQ==",
       "dependencies": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -15330,7 +15330,7 @@
         "callsite-record": "^4.0.0",
         "chai": "4.3.4",
         "chalk": "^2.3.0",
-        "chrome-remote-interface": "^0.30.0",
+        "chrome-remote-interface": "^0.31.3",
         "coffeescript": "^2.3.1",
         "commander": "^8.3.0",
         "debug": "^4.3.1",
@@ -15384,9 +15384,9 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "28.1.0",
+        "testcafe-hammerhead": "28.2.5",
         "testcafe-legacy-api": "5.1.6",
-        "testcafe-reporter-dashboard": "^0.2.7",
+        "testcafe-reporter-dashboard": "^0.2.10",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -15589,9 +15589,9 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-28.1.0.tgz",
-      "integrity": "sha512-6J+U1MEV8L7OI467tkpOpewqYE6u0bhDTGQhK1s8cvDZtcvzm1ArFTRJvyG1wMb3/QaGrzoCHpEMRJ2BIK/0lw==",
+      "version": "28.2.5",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-28.2.5.tgz",
+      "integrity": "sha512-N0SCrJgyUANYRohbenS1nSmJwjTGvTDFMBwNiAGbG+5Z87O/hXT6XOYBy5W/y/zcSX9G2lZ4Y1RN24wo5WMcEA==",
       "dependencies": {
         "acorn-hammerhead": "0.6.1",
         "asar": "^2.0.1",
@@ -15788,9 +15788,9 @@
       "integrity": "sha512-PCqteQ5+vlqNvLMljq6QrTFmmRVQNSW1iGbRDUv4gif8V4L5OXTZPIU0RyRusKpk7gu5wKyCE0CT7hC7V9+/mg=="
     },
     "node_modules/testcafe-reporter-sauce-json": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.6.0.tgz",
-      "integrity": "sha512-Bq12Nm1oE65Zy7nM6vWGWW1MnErrUZ+2l/vZIkOl/8AUy70OVuUG6mYUbo+tGr3DoXTgdE5O+XZVha1ZQoIvaA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.7.0.tgz",
+      "integrity": "sha512-WwJ2vMAsUAqJQMle0lwDfJPdi29Cen0g6QOJBBfk1ietp1R30MBm6LGzFhqTPwJ4cVnlY4lI4g2hiS0jP/s8TA==",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "1.1.0",
         "callsite-record": "^4.1.4"
@@ -19988,9 +19988,9 @@
       }
     },
     "chrome-remote-interface": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.30.1.tgz",
-      "integrity": "sha512-emKaqCjYAgrT35nm6PvTUKJ++2NX9qAmrcNRPRGyryG9Kc7wlkvO0bmvEdNMrr8Bih2e149WctJZFzUiM1UNwg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz",
+      "integrity": "sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==",
       "requires": {
         "commander": "2.11.x",
         "ws": "^7.2.0"
@@ -28205,9 +28205,9 @@
       }
     },
     "testcafe": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.1.0.tgz",
-      "integrity": "sha512-mfF9UX2U9RyjNfuviaOf/MYEQA7uGxe0n+VXJzdPMqpPjvILe/LrAopyxjkmW5MllZAGW0/tmwOy9xRZl50l7A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.2.0.tgz",
+      "integrity": "sha512-ipZTM9lKQU9qM+Dv3Vobm02TrRFFJmfbkwiBJjpYh0YG18/l96Q/RX5D8KmuNDi3EmbJRLIWRkXIJ40AwUJnUQ==",
       "requires": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -28236,7 +28236,7 @@
         "callsite-record": "^4.0.0",
         "chai": "4.3.4",
         "chalk": "^2.3.0",
-        "chrome-remote-interface": "^0.30.0",
+        "chrome-remote-interface": "^0.31.3",
         "coffeescript": "^2.3.1",
         "commander": "^8.3.0",
         "debug": "^4.3.1",
@@ -28290,9 +28290,9 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "28.1.0",
+        "testcafe-hammerhead": "28.2.5",
         "testcafe-legacy-api": "5.1.6",
-        "testcafe-reporter-dashboard": "^0.2.7",
+        "testcafe-reporter-dashboard": "^0.2.10",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
@@ -28598,9 +28598,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-28.1.0.tgz",
-      "integrity": "sha512-6J+U1MEV8L7OI467tkpOpewqYE6u0bhDTGQhK1s8cvDZtcvzm1ArFTRJvyG1wMb3/QaGrzoCHpEMRJ2BIK/0lw==",
+      "version": "28.2.5",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-28.2.5.tgz",
+      "integrity": "sha512-N0SCrJgyUANYRohbenS1nSmJwjTGvTDFMBwNiAGbG+5Z87O/hXT6XOYBy5W/y/zcSX9G2lZ4Y1RN24wo5WMcEA==",
       "requires": {
         "acorn-hammerhead": "0.6.1",
         "asar": "^2.0.1",
@@ -28777,9 +28777,9 @@
       "integrity": "sha512-PCqteQ5+vlqNvLMljq6QrTFmmRVQNSW1iGbRDUv4gif8V4L5OXTZPIU0RyRusKpk7gu5wKyCE0CT7hC7V9+/mg=="
     },
     "testcafe-reporter-sauce-json": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.6.0.tgz",
-      "integrity": "sha512-Bq12Nm1oE65Zy7nM6vWGWW1MnErrUZ+2l/vZIkOl/8AUy70OVuUG6mYUbo+tGr3DoXTgdE5O+XZVha1ZQoIvaA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-sauce-json/-/testcafe-reporter-sauce-json-0.7.0.tgz",
+      "integrity": "sha512-WwJ2vMAsUAqJQMle0lwDfJPdi29Cen0g6QOJBBfk1ietp1R30MBm6LGzFhqTPwJ4cVnlY4lI4g2hiS0jP/s8TA==",
       "requires": {
         "@saucelabs/sauce-json-reporter": "1.1.0",
         "callsite-record": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "dotenv": "16.0.3",
     "mocha-junit-reporter": "^2.2.0",
     "sauce-testrunner-utils": "0.6.1",
-    "testcafe": "2.1.0",
+    "testcafe": "2.2.0",
     "testcafe-browser-provider-ios": "0.5.0",
-    "testcafe-reporter-sauce-json": "0.6.0",
+    "testcafe-reporter-sauce-json": "0.7.0",
     "typescript": "4.9.3",
     "xml-js": "1.6.11",
     "yargs": "17.6.2"


### PR DESCRIPTION
This PR:
- Updates `testcafe` to 2.2.0
- Updates `testcafe-reporter-sauce-json` to 0.7.0.
- Fixes most of security issues with `npm audit fix`.