### PR TITLE
[DEVX-2107] Fix compiler path

### DIFF
--- a/src/testcafe-runner.js
+++ b/src/testcafe-runner.js
@@ -99,10 +99,10 @@ async function runReporter ({ suiteName, results, metrics, assetsPath, browserNa
 function buildCompilerOptions (compilerOptions) {
   const args = [];
   if (compilerOptions?.typescript?.configPath) {
-    args.push(`typescript.configPath='${compilerOptions?.typescript?.configPath}'`);
+    args.push(`typescript.configPath=${compilerOptions?.typescript?.configPath}`);
   }
   if (compilerOptions?.typescript?.customCompilerModulePath) {
-    args.push(`typescript.customCompilerModulePath='${compilerOptions?.typescript?.customCompilerModulePath}'`);
+    args.push(`typescript.customCompilerModulePath=${compilerOptions?.typescript?.customCompilerModulePath}`);
   }
   for (const key in compilerOptions?.typescript?.options) {
     args.push(`typescript.options.${key}=${compilerOptions?.typescript?.options[key]}`);

--- a/src/testcafe-runner.js
+++ b/src/testcafe-runner.js
@@ -107,7 +107,7 @@ function buildCompilerOptions (compilerOptions) {
   for (const key in compilerOptions?.typescript?.options) {
     args.push(`typescript.options.${key}=${compilerOptions?.typescript?.options[key]}`);
   }
-  return args.join(',');
+  return args.join(';');
 }
 
 // Buid the command line to invoke TestCafe with all required parameters

--- a/tests/unit/src/testcafe-runner.spec.js
+++ b/tests/unit/src/testcafe-runner.spec.js
@@ -33,7 +33,7 @@ describe('.buildCommandLine', function () {
     expect(cli).toMatchObject([
       'firefox:headless:marionettePort=9223',
       '**/*.test.js',
-      '--compiler-options', 'typescript.configPath=\'tsconfig.json\',typescript.customCompilerModulePath=\'/compiler/path\'',
+      '--compiler-options', 'typescript.configPath=tsconfig.json;typescript.customCompilerModulePath=/compiler/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--reporter',
@@ -257,7 +257,7 @@ describe('.buildCompilerOptions', function () {
         configPath: './tsconfig.json',
       },
     };
-    const expected = `typescript.configPath='./tsconfig.json'`;
+    const expected = `typescript.configPath=./tsconfig.json`;
     expect(buildCompilerOptions(input)).toEqual(expected);
   });
   it('CustomCompilerPath set', function () {
@@ -266,7 +266,7 @@ describe('.buildCompilerOptions', function () {
         customCompilerModulePath: '/path/to/custom/compiler',
       },
     };
-    const expected = `typescript.customCompilerModulePath='/path/to/custom/compiler'`;
+    const expected = `typescript.customCompilerModulePath=/path/to/custom/compiler`;
     expect(buildCompilerOptions(input)).toEqual(expected);
   });
   it('With options', function () {
@@ -279,7 +279,7 @@ describe('.buildCompilerOptions', function () {
         },
       },
     };
-    const expected = 'typescript.options.allowUnusedLabels=true,typescript.options.noFallthroughCasesInSwitch=true,typescript.options.allowUmdGlobalAccess=true';
+    const expected = 'typescript.options.allowUnusedLabels=true;typescript.options.noFallthroughCasesInSwitch=true;typescript.options.allowUmdGlobalAccess=true';
     expect(buildCompilerOptions(input)).toEqual(expected);
   });
   it('All with options', function () {
@@ -294,7 +294,7 @@ describe('.buildCompilerOptions', function () {
         },
       },
     };
-    const expected = `typescript.configPath='./tsconfig.json',typescript.customCompilerModulePath='/path/to/custom/compiler',typescript.options.allowUnusedLabels=true,typescript.options.noFallthroughCasesInSwitch=true,typescript.options.allowUmdGlobalAccess=true`;
+    const expected = `typescript.configPath=./tsconfig.json;typescript.customCompilerModulePath=/path/to/custom/compiler;typescript.options.allowUnusedLabels=true;typescript.options.noFallthroughCasesInSwitch=true;typescript.options.allowUmdGlobalAccess=true`;
     expect(buildCompilerOptions(input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
testcafe always takes `CONFIG_PATH` from `typescript.configPath=${CONFIG_PATH}` as an entire config. Any quotes around file path in this field would be treated as parts of file path. That's why it returns `ERROR "/Volumes/Sauce/saucectl-runners/sauce-testcafe-runner/2.2.0/bundle/__project__/'apps/us/e2e/sanity/tsconfig-sauce.json'" is not a valid TypeScript configuration file.` 

The testcafe docs is not accurate. https://testcafe.io/documentation/402639/reference/command-line-interface#--compiler-options-options
```
To list multiple parameters, separate them with semicolons. Enclose values that contain spaces in quotes.
```

With this fix, it can also handle file path with empty string. While this PR is only fixing the quotes and spaces in the config path. For special characters,  I'd suggest we should also add some notes in docs to suggest using a proper named tsconfig files.