### PR TITLE
Bump testcafe@2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "16.0.3",
         "mocha-junit-reporter": "^2.2.0",
         "sauce-testrunner-utils": "1.0.0",
-        "testcafe": "2.3.1",
+        "testcafe": "2.5.0",
         "testcafe-browser-provider-ios": "0.5.0",
         "testcafe-reporter-saucelabs": "1.0.1",
         "typescript": "^5.0.4",
@@ -1843,6 +1843,31 @@
       "integrity": "sha512-fneVypElGUH6Be39mlRZeAu00pccTlf4oVuzf9xPJD1cdEqI8NyAiQua/EW7lZdrbMUbgyXcJmfKPefhYius3A==",
       "dependencies": {
         "stackframe": "^1.1.1"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.4.tgz",
+      "integrity": "sha512-lykfY3TJRRWFeTxccEKdf1I6BLl2Plw81H0bbp4Fc5iEc67foDCa5pjJQULVgo0wF+Dli75f3xVcdb/67FFZ/g==",
+      "dependencies": {
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3890,46 +3915,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asar": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/asar/-/asar-2.1.0.tgz",
-      "integrity": "sha512-d2Ovma+bfqNpvBzY/KU8oPY67ZworixTpkjSx0PCXnQi67c2cXmssaTxpFDUM0ttopXoGx/KRxNg/GDThYbXQA==",
-      "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
-      "dependencies": {
-        "chromium-pickle-js": "^0.2.0",
-        "commander": "^2.20.0",
-        "cuint": "^0.2.2",
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "tmp-promise": "^1.0.5"
-      },
-      "bin": {
-        "asar": "bin/asar.js"
-      },
-      "engines": {
-        "node": ">=8.0"
-      },
-      "optionalDependencies": {
-        "@types/glob": "^7.1.1"
-      }
-    },
-    "node_modules/asar/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/asar/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -4358,11 +4343,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -4750,9 +4730,9 @@
       }
     },
     "node_modules/chrome-remote-interface": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz",
-      "integrity": "sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.32.2.tgz",
+      "integrity": "sha512-3UbFKtEmqApehPQnqdblcggx7KveQphEMKQmdJZsOguE9ylw2N2/9Z7arO7xS55+DBJ/hyP8RrayLt4MMdJvQg==",
       "dependencies": {
         "commander": "2.11.x",
         "ws": "^7.2.0"
@@ -5164,11 +5144,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5578,6 +5553,15 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "node_modules/des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -6432,9 +6416,9 @@
       "dev": true
     },
     "node_modules/esotope-hammerhead": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.3.tgz",
-      "integrity": "sha512-Aq6gUznvm0xPtjpbZo9OSsRO1+m+NM0hjZOYufH3HDlJWeOZpBskR/vuP9/tiMaQFD3+ES5BQq5fAY1qOLKWUA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.4.tgz",
+      "integrity": "sha512-QY4HXqvjLSFGoGgHvm3H1QUMNcpwnUpGRBaVVFWE5uqbPQh9HSWcA1YD7KwwL/IrgerDwZn00z5dtYT9Ot/C/A==",
       "dependencies": {
         "@types/estree": "0.0.46"
       }
@@ -7409,6 +7393,38 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/httpntlm": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.12.tgz",
+      "integrity": "sha512-dqdye5b5OmzCIDrA2JgkKG7bV9sK0S5VUELD1+JcRZG6ZDieAW7/c0MPsqlTRKDzso1tIMhvDQAWvfgFN0yg3A==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://www.paypal.com/donate/?hosted_button_id=2CKNJLZJBW8ZC"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/samdecrock"
+        }
+      ],
+      "dependencies": {
+        "des.js": "^1.0.1",
+        "httpreq": ">=0.4.22",
+        "js-md4": "^0.3.2",
+        "underscore": "~1.12.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/httpreq": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.5.2.tgz",
+      "integrity": "sha512-2Jm+x9WkExDOeFRrdBCBSpLPT5SokTcRHkunV3pjKmX/cx6av8zQ0WtHUMDrYb6O4hBFzNU6sxJEypvRUVYKnw==",
+      "engines": {
+        "node": ">= 6.15.1"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10043,6 +10059,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10632,6 +10653,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -15661,6 +15687,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -16169,9 +16200,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.3.1.tgz",
-      "integrity": "sha512-UkYlf0h6BwsmVSGGQFkROIFfWXjW/lSCXfaPd9gK+rbECKFXmSbkvW45xv7k/S4t0LeJJAaF+gZuouc34SuLdQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.5.0.tgz",
+      "integrity": "sha512-msRwIRuc7PXmpKzI9T9CFhNVDqW7JO5XGgVs8wHORKm3jfbBjw9ouRgoqTH+eHGTTB8Hnd8Jdt/2off68Z6ONQ==",
       "dependencies": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -16200,7 +16231,7 @@
         "callsite-record": "^4.0.0",
         "chai": "4.3.4",
         "chalk": "^2.3.0",
-        "chrome-remote-interface": "^0.31.3",
+        "chrome-remote-interface": "^0.32.1",
         "coffeescript": "^2.3.1",
         "commander": "^8.3.0",
         "debug": "^4.3.1",
@@ -16251,10 +16282,11 @@
         "resolve-from": "^4.0.0",
         "sanitize-filename": "^1.6.0",
         "semver": "^5.6.0",
+        "set-cookie-parser": "^2.5.1",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "28.4.2",
+        "testcafe-hammerhead": "30.1.0",
         "testcafe-legacy-api": "5.1.6",
         "testcafe-reporter-dashboard": "^0.2.10",
         "testcafe-reporter-json": "^2.1.0",
@@ -16263,6 +16295,7 @@
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.2.1",
         "testcafe-safe-storage": "^1.1.1",
+        "testcafe-selector-generator": "^0.1.0",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.2.2",
@@ -16274,7 +16307,7 @@
         "testcafe": "bin/testcafe-with-v8-flag-filter.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/testcafe-browser-provider-ios": {
@@ -16461,18 +16494,19 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "28.4.2",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-28.4.2.tgz",
-      "integrity": "sha512-Q0Zy4OLOjadyzmEEef2JOsgD4D3GZLCy38x8v2qeGpnQG8FMJ6Yhm7upnYbkx5T3xqWKHro02wQZ61ldclVboQ==",
+      "version": "31.2.0",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.2.0.tgz",
+      "integrity": "sha512-RfOXdCtRgsOd4778FRQoJGfltzV5VQqSHekbZhdh/05eHGcYM0QcmDNKgzp5ihbEUx9ZnNeWswCpxsH1G1hWXA==",
       "dependencies": {
+        "@electron/asar": "^3.2.3",
         "acorn-hammerhead": "0.6.1",
-        "asar": "^2.0.1",
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
         "css": "2.2.3",
         "debug": "4.3.1",
-        "esotope-hammerhead": "0.6.3",
+        "esotope-hammerhead": "0.6.4",
         "http-cache-semantics": "^4.1.0",
+        "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",
         "lodash": "^4.17.20",
         "lru-cache": "2.6.3",
@@ -16487,8 +16521,7 @@
         "read-file-relative": "^1.2.0",
         "semver": "5.5.0",
         "tough-cookie": "4.0.0",
-        "tunnel-agent": "0.6.0",
-        "webauth": "^1.1.0"
+        "tunnel-agent": "0.6.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -16713,6 +16746,11 @@
       "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.4.tgz",
       "integrity": "sha512-25a2Z7i/N8oCF2gSJT6fQtyfcrrdI788gQRx1hBNpoNK2InYxX5QYFHjgeIqJaQIQZDdUQFgA1DIQtPkfaJHpQ=="
     },
+    "node_modules/testcafe-selector-generator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-selector-generator/-/testcafe-selector-generator-0.1.0.tgz",
+      "integrity": "sha512-MTw+RigHsEYmFgzUFNErDxui1nTYUk6nm2bmfacQiKPdhJ9AHW/wue4J/l44mhN8x3E8NgOUkHHOI+1TDFXiLQ=="
+    },
     "node_modules/testcafe/node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
@@ -16722,6 +16760,22 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+    },
+    "node_modules/testcafe/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/testcafe/node_modules/dedent": {
       "version": "0.4.0",
@@ -16742,6 +16796,14 @@
       "integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/testcafe/node_modules/esotope-hammerhead": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.3.tgz",
+      "integrity": "sha512-Aq6gUznvm0xPtjpbZo9OSsRO1+m+NM0hjZOYufH3HDlJWeOZpBskR/vuP9/tiMaQFD3+ES5BQq5fAY1qOLKWUA==",
+      "dependencies": {
+        "@types/estree": "0.0.46"
       }
     },
     "node_modules/testcafe/node_modules/execa": {
@@ -16788,6 +16850,17 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/testcafe/node_modules/iconv-lite": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+      "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/testcafe/node_modules/is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -16832,6 +16905,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/testcafe/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/testcafe/node_modules/lru-cache": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
+      "integrity": "sha512-qkisDmHMe8gxKujmC1BdaqgkoFlioLDCUwaFBA3lX8Ilhr3YzsasbGYaiADMjxQnj+aiZUKgGKe/BN3skMwXWw=="
+    },
+    "node_modules/testcafe/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/testcafe/node_modules/resolve-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
@@ -16859,6 +16956,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/testcafe/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/testcafe/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -16876,6 +16978,14 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/testcafe/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/testcafe/node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -16885,6 +16995,66 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-30.1.0.tgz",
+      "integrity": "sha512-82vSAAQvBEsgUNVIusb6mSEpyUGv0r0bzT0vXRqLqKSSYRjgXSK8k0PR5Q+YErGlR5k5gmBqVQYuFgMsWUQpWg==",
+      "dependencies": {
+        "@electron/asar": "^3.2.3",
+        "acorn-hammerhead": "0.6.1",
+        "bowser": "1.6.0",
+        "crypto-md5": "^1.0.0",
+        "css": "2.2.3",
+        "debug": "4.3.1",
+        "esotope-hammerhead": "0.6.3",
+        "http-cache-semantics": "^4.1.0",
+        "httpntlm": "^1.8.10",
+        "iconv-lite": "0.5.1",
+        "lodash": "^4.17.20",
+        "lru-cache": "2.6.3",
+        "match-url-wildcard": "0.0.4",
+        "merge-stream": "^1.0.1",
+        "mime": "~1.4.1",
+        "mustache": "^2.1.1",
+        "nanoid": "^3.1.12",
+        "os-family": "^1.0.0",
+        "parse5": "2.2.3",
+        "pinkie": "2.0.4",
+        "read-file-relative": "^1.2.0",
+        "semver": "5.5.0",
+        "tough-cookie": "4.0.0",
+        "tunnel-agent": "0.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/bowser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+      "integrity": "sha512-Fk23J0+vRnI2eKDEDoUZXWtbMjijr098lKhuj4DKAfMKMCRVfJOuxXlbpxy0sTgbZ/Nr2N8MexmOir+GGI/ZMA=="
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==",
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/parse5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "integrity": "sha512-yJQdbcT+hCt6HD+BuuUvjHUdNwerQIKSJSm7tXjtp6oIH5Mxbzlt/VIIeWxblsgcDt1+E7kxPeilD5McWswStA=="
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/testcafe/node_modules/tmp": {
@@ -16952,37 +17122,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.1.0.tgz",
-      "integrity": "sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "tmp": "0.1.0"
-      }
-    },
-    "node_modules/tmp-promise/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/tmp-promise/node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tmpl": {
@@ -17283,6 +17422,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -17604,14 +17748,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webauth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webauth/-/webauth-1.1.0.tgz",
-      "integrity": "sha512-BwbI3vESF7eVleIU6zYPnFuzT89IRswYoJ0C6xYLDpNSUpiw7pdX0HjebyYkFYt1IuYnQvx2Y1Lx+bGKz4Zi6w==",
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "16.0.3",
     "mocha-junit-reporter": "^2.2.0",
     "sauce-testrunner-utils": "1.0.0",
-    "testcafe": "2.3.1",
+    "testcafe": "2.5.0",
     "testcafe-browser-provider-ios": "0.5.0",
     "testcafe-reporter-saucelabs": "1.0.1",
     "typescript": "^5.0.4",

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -160,6 +160,12 @@ export function buildCommandLine (suite: Suite|undefined, projectPath: string, a
       cli.push('--compiler-options', options);
     }
   }
+  if (suite.nativeAutomation) {
+    cli.push('--native-automation');
+  }
+  if (suite.esm) {
+    cli.push('--esm');
+  }
 
   // Record a video if it's not a VM or if SAUCE_VIDEO_RECORD is set
   const shouldRecordVideo = !suite.disableVideo;

--- a/src/type.ts
+++ b/src/type.ts
@@ -83,6 +83,8 @@ export type Suite = {
   screenshots?: Screenshots,
   filter?: Filter,
   preExec?: string[],
+  nativeAutomation?: boolean;
+  esm?: boolean;
 }
 
 export type TestCafeConfig = {

--- a/tests/cloud/.sauce/config.yml
+++ b/tests/cloud/.sauce/config.yml
@@ -24,6 +24,7 @@ suites:
   - name: "Win10 - Firefox"
     platformName: "Windows 10"
     browserName: "firefox"
+    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -37,6 +38,7 @@ suites:
   - name: "Win11 - Firefox"
     platformName: "Windows 11"
     browserName: "firefox"
+    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -50,6 +52,7 @@ suites:
   - name: "macOS11 - Firefox"
     platformName: "macOS 11.00"
     browserName: "firefox"
+    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -69,6 +72,7 @@ suites:
   - name: "macOS12 - Firefox"
     platformName: "macOS 12"
     browserName: "firefox"
+    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -88,6 +92,7 @@ suites:
   - name: "macOS13 - Firefox"
     platformName: "macOS 13"
     browserName: "firefox"
+    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1

--- a/tests/cloud/.sauce/config.yml
+++ b/tests/cloud/.sauce/config.yml
@@ -24,7 +24,6 @@ suites:
   - name: "Win10 - Firefox"
     platformName: "Windows 10"
     browserName: "firefox"
-    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -38,7 +37,6 @@ suites:
   - name: "Win11 - Firefox"
     platformName: "Windows 11"
     browserName: "firefox"
-    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -52,7 +50,6 @@ suites:
   - name: "macOS11 - Firefox"
     platformName: "macOS 11.00"
     browserName: "firefox"
-    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -72,7 +69,6 @@ suites:
   - name: "macOS12 - Firefox"
     platformName: "macOS 12"
     browserName: "firefox"
-    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1
@@ -92,7 +88,6 @@ suites:
   - name: "macOS13 - Firefox"
     platformName: "macOS 13"
     browserName: "firefox"
-    browserVersion: "111"
     src:
       - "tests/no-sc/**/*.test.js"
     speed: 1

--- a/tests/cloud/tests/no-sc/sauceswag.ok.test.js
+++ b/tests/cloud/tests/no-sc/sauceswag.ok.test.js
@@ -42,7 +42,7 @@ test('SwagLabs standard user login', async function (t) {
     .typeText(login.usernameEl, Users.standard)
     .typeText(login.passwordEl, Users.password)
     .click('.btn_action')
-    .takeScreenshot()
-  // Use the assertion to check if the actual header text is equal to the expected one
+    // .takeScreenshot()
+    // Use the assertion to check if the actual header text is equal to the expected one
     .expect(Selector('#inventory_container').visible).eql(true);
 });


### PR DESCRIPTION
Also add support for new 2.5.0 features:
* `--native-automation`
* `--esm`

Add them now to the runner and we can update saucectl after release.