### PR TITLE
Update command to parse testcafe version

### DIFF
--- a/.github/helpers/generate-release-notes.sh
+++ b/.github/helpers/generate-release-notes.sh
@@ -4,7 +4,7 @@
 CHANGELOG=$(git --no-pager log --no-notes --no-decorate --oneline  v${1}...HEAD)
 
 ## Gather Framework version
-TESTCAFE_VER=$(< package-lock.json jq -r '.packages[""].dependencies["testcafe"]')
+TESTCAFE_VER=$(npm list testcafe --json --package-lock-only | jq --raw-output '.dependencies["testcafe"].version')
 NODEJS_VER=$(cat .nvmrc | tr -d "v")
 
 ## Generate everything

--- a/.github/helpers/generate-release-notes.sh
+++ b/.github/helpers/generate-release-notes.sh
@@ -4,7 +4,7 @@
 CHANGELOG=$(git --no-pager log --no-notes --no-decorate --oneline  v${1}...HEAD)
 
 ## Gather Framework version
-TESTCAFE_VER=$(< package-lock.json jq -r '.dependencies["testcafe"].version')
+TESTCAFE_VER=$(< package-lock.json jq -r '.packages[""].dependencies["testcafe"]')
 NODEJS_VER=$(cat .nvmrc | tr -d "v")
 
 ## Generate everything


### PR DESCRIPTION
package-lock was recently updated to lockfileVersion: 3 and with that update the "dependencies" object was removed (which was unused since lockfileVersion: 1, but remained for backwards compatibility).