### PR TITLE
Bump testcafe@3.0.1 + npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "16.0.3",
         "mocha-junit-reporter": "^2.2.0",
         "sauce-testrunner-utils": "1.3.0",
-        "testcafe": "2.6.2",
+        "testcafe": "3.0.1",
         "testcafe-browser-provider-ios": "0.5.0",
         "testcafe-reporter-saucelabs": "2.0.0",
         "typescript": "^5.0.4",
@@ -2650,14 +2650,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
-    "node_modules/@miherlosev/esm": {
-      "version": "3.2.26",
-      "resolved": "https://registry.npmjs.org/@miherlosev/esm/-/esm-3.2.26.tgz",
-      "integrity": "sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -2700,21 +2692,18 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
-      "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
       "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
@@ -2730,9 +2719,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-      "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
@@ -2744,9 +2733,9 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
-      "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
       "dev": true,
       "dependencies": {
         "@octokit/request": "^6.0.0",
@@ -2758,18 +2747,19 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
-      "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^9.0.0"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
       },
       "engines": {
         "node": ">= 14"
@@ -2788,13 +2778,12 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
-      "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.3.1"
+        "@octokit/types": "^10.0.0"
       },
       "engines": {
         "node": ">= 14"
@@ -2803,10 +2792,19 @@
         "@octokit/core": ">=3"
       }
     },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@octokit/request": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
-      "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
       "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
@@ -2835,9 +2833,9 @@
       }
     },
     "node_modules/@octokit/request/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2855,27 +2853,33 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
-      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
+      "version": "19.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
+      "integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
       "dev": true,
       "dependencies": {
-        "@octokit/core": "^4.1.0",
-        "@octokit/plugin-paginate-rest": "^6.0.0",
+        "@octokit/core": "^4.2.1",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
         "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
       },
       "engines": {
         "node": ">= 14"
       }
     },
+    "node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "dev": true
+    },
     "node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
+        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2976,15 +2980,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@tsconfig/node18": {
@@ -3218,9 +3213,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3376,9 +3371,9 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3520,9 +3515,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3579,9 +3574,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3655,15 +3650,15 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dev": true,
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -4280,6 +4275,15 @@
         }
       ]
     },
+    "node_modules/basic-ftp": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
+      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -4312,29 +4316,6 @@
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/bowser": {
@@ -4525,15 +4506,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -4766,24 +4738,21 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^4.0.0"
+        "restore-cursor": "^3.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
-      "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5409,18 +5378,18 @@
       }
     },
     "node_modules/degenerator": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.3.tgz",
-      "integrity": "sha512-FTq/qYMeBJACu1gHcXJvzsRBTK6aw5zWCYbEnIOyamOt5UJufWJRQ5XfDb6OuayfJWvmWAHgcZyt43vm/hbj7g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-4.0.4.tgz",
+      "integrity": "sha512-MTZdZsuNxSBL92rsjx3VFWe57OpRlikyLbcx2B5Dmdv6oScqpMrvpY7zHLMymrUxo3U5+suPUMsNgW/+SZB1lg==",
       "dev": true,
       "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.11"
+        "ast-types": "^0.13.4",
+        "escodegen": "^1.14.3",
+        "esprima": "^4.0.1",
+        "vm2": "^3.9.19"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/del": {
@@ -5498,15 +5467,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/deprecation": {
@@ -6319,9 +6279,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6647,15 +6607,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-      "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6812,19 +6763,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/ftp": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-      "integrity": "sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6956,29 +6894,27 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-      "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.1.tgz",
+      "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^5.0.1",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
+      "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
       "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/getos": {
@@ -7108,9 +7044,9 @@
       }
     },
     "node_modules/got": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
-      "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
@@ -7275,34 +7211,17 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
-    "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http-status-codes": {
@@ -7356,16 +7275,16 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
       "dev": true,
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -7540,68 +7459,90 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/inquirer": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.5.tgz",
-      "integrity": "sha512-3ygAIh8gcZavV9bj6MTdYddG2zPSYswP808fKS46NOwlF0zZljVpnLCHODDqItWJDbDpLb3aouAxGaJbkxoppA==",
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.6.tgz",
+      "integrity": "sha512-y71l237eJJKS4rl7sQcEUiMhrR0pB/ZnRMMTxLpjJhWL4hdWCT03a6jJnC1w6qIPSRZWEozuieGt3v7XaEJYFw==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^6.0.0",
+        "ansi-escapes": "^4.3.2",
         "chalk": "^5.2.0",
-        "cli-cursor": "^4.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^4.0.0",
         "external-editor": "^3.0.3",
         "figures": "^5.0.0",
         "lodash": "^4.17.21",
         "mute-stream": "1.0.0",
-        "ora": "^6.1.2",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.8.0",
-        "string-width": "^5.1.2",
-        "strip-ansi": "^7.0.1",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "through": "^2.3.6",
-        "wrap-ansi": "^8.1.0"
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=14.18.0"
       }
     },
-    "node_modules/inquirer/node_modules/ansi-escapes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.1.0.tgz",
-      "integrity": "sha512-bQyg9bzRntwR/8b89DOEhGwctcwCrbWW/TuqTQnpqpy5Fz3aovcOTj5i8NJV6AHc8OGNdMaqdxAWww8pz2kiKg==",
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^3.0.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+    "node_modules/inquirer/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/inquirer/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7610,31 +7551,125 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/inquirer/node_modules/type-fest": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
-      "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==",
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
-        "node": ">=14.16"
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -9523,9 +9558,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10884,15 +10919,17 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.4.tgz",
-      "integrity": "sha512-8/Mct0X/w77PmgIpSlXfNIOlrZBfT+8966zLCxOhwi1qZ2Ueyy99uWPSDW6bt2OKw1NzrvHJBSgkzAvn1iWuhw==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
+        "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
@@ -10943,10 +10980,10 @@
         "proc-log",
         "qrcode-terminal",
         "read",
-        "read-package-json",
-        "read-package-json-fast",
         "semver",
+        "sigstore",
         "ssri",
+        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -10957,71 +10994,73 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.2.7",
-        "@npmcli/config": "^6.1.5",
-        "@npmcli/map-workspaces": "^3.0.3",
-        "@npmcli/package-json": "^3.0.0",
-        "@npmcli/run-script": "^6.0.0",
+        "@npmcli/arborist": "^6.3.0",
+        "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/map-workspaces": "^3.0.4",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^17.0.5",
-        "chalk": "^4.1.2",
+        "cacache": "^17.1.3",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.1",
-        "glob": "^9.3.2",
+        "fs-minipass": "^3.0.2",
+        "glob": "^10.2.7",
         "graceful-fs": "^4.2.11",
         "hosted-git-info": "^6.1.1",
-        "ini": "^3.0.1",
+        "ini": "^4.1.1",
         "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.15",
-        "libnpmexec": "^5.0.15",
-        "libnpmfund": "^4.0.15",
+        "libnpmdiff": "^5.0.19",
+        "libnpmexec": "^6.0.3",
+        "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
-        "libnpmorg": "^5.0.3",
-        "libnpmpack": "^5.0.15",
-        "libnpmpublish": "^7.1.3",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.19",
+        "libnpmpublish": "^7.5.0",
         "libnpmsearch": "^6.0.2",
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
-        "make-fetch-happen": "^11.0.3",
-        "minimatch": "^7.4.3",
-        "minipass": "^4.2.5",
+        "make-fetch-happen": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^9.3.1",
-        "nopt": "^7.1.0",
-        "npm-audit-report": "^4.0.0",
-        "npm-install-checks": "^6.1.0",
+        "node-gyp": "^9.4.0",
+        "nopt": "^7.2.0",
+        "npm-audit-report": "^5.0.0",
+        "npm-install-checks": "^6.1.1",
         "npm-package-arg": "^10.1.0",
         "npm-pick-manifest": "^8.0.1",
         "npm-profile": "^7.0.1",
-        "npm-registry-fetch": "^14.0.3",
+        "npm-registry-fetch": "^14.0.5",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^15.1.1",
+        "pacote": "^15.2.0",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.0.0",
-        "read-package-json": "^6.0.1",
-        "read-package-json-fast": "^3.0.2",
-        "semver": "^7.3.8",
-        "ssri": "^10.0.2",
-        "tar": "^6.1.13",
+        "read": "^2.1.0",
+        "semver": "^7.5.4",
+        "sigstore": "^1.7.0",
+        "ssri": "^10.0.4",
+        "supports-color": "^9.4.0",
+        "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
         "validate-npm-package-name": "^5.0.0",
-        "which": "^3.0.0",
-        "write-file-atomic": "^5.0.0"
+        "which": "^3.0.1",
+        "write-file-atomic": "^5.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -11053,8 +11092,69 @@
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -11062,7 +11162,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "6.2.7",
+      "version": "6.3.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11073,7 +11173,7 @@
         "@npmcli/metavuln-calculator": "^5.0.0",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^3.0.0",
+        "@npmcli/package-json": "^4.0.0",
         "@npmcli/query": "^3.0.0",
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "^4.0.1",
@@ -11082,7 +11182,7 @@
         "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^7.4.2",
+        "minimatch": "^9.0.0",
         "nopt": "^7.0.0",
         "npm-install-checks": "^6.0.0",
         "npm-package-arg": "^10.1.0",
@@ -11098,7 +11198,7 @@
         "semver": "^7.3.7",
         "ssri": "^10.0.1",
         "treeverse": "^3.0.0",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "bin": {
         "arborist": "bin/index.js"
@@ -11108,17 +11208,18 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "6.1.5",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
-        "ini": "^3.0.0",
+        "ci-info": "^3.8.0",
+        "ini": "^4.1.0",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11147,7 +11248,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "4.0.4",
+      "version": "4.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11180,13 +11281,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.3",
+      "version": "3.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/name-from-folder": "^2.0.0",
-        "glob": "^9.3.1",
-        "minimatch": "^7.4.2",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
         "read-package-json-fast": "^3.0.0"
       },
       "engines": {
@@ -11194,7 +11295,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11209,7 +11310,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "2.0.1",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -11236,11 +11336,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "3.0.0",
+      "version": "4.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0"
+        "@npmcli/git": "^4.1.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^6.1.1",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^5.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11269,7 +11375,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11283,10 +11389,31 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
       "inBundle": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.1.0",
+        "tuf-js": "^1.1.7"
+      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -11299,12 +11426,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "1.0.1",
+      "version": "1.0.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^7.4.2"
+        "@tufjs/canonical-json": "1.0.0",
+        "minimatch": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11434,7 +11570,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11495,20 +11631,19 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "17.0.5",
+      "version": "17.1.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^9.3.1",
+        "glob": "^10.2.2",
         "lru-cache": "^7.7.1",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
         "ssri": "^10.0.0",
         "tar": "^6.1.11",
         "unique-filename": "^3.0.0"
@@ -11518,15 +11653,11 @@
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "5.3.0",
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -11666,6 +11797,33 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
       "inBundle": true,
@@ -11730,6 +11888,11 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/npm/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -11773,6 +11936,11 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "inBundle": true,
@@ -11781,12 +11949,27 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.1",
+    "node_modules/npm/node_modules/foreground-child": {
+      "version": "3.1.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^4.0.0"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11803,7 +11986,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11811,7 +11994,7 @@
         "color-support": "^1.1.3",
         "console-control-strings": "^1.1.0",
         "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.0.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
@@ -11821,14 +12004,18 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "9.3.2",
+      "version": "10.2.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^7.4.1",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11851,14 +12038,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/has-unicode": {
@@ -11947,11 +12126,11 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^7.4.2"
+        "minimatch": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11975,7 +12154,6 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
@@ -11993,11 +12171,11 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.1",
+      "version": "4.1.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
@@ -12042,7 +12220,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.11.0",
+      "version": "2.12.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12069,6 +12247,23 @@
       "version": "2.0.0",
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/jackspeak": {
+      "version": "2.2.1",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
@@ -12117,16 +12312,16 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "5.0.15",
+      "version": "5.0.19",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.7",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/disparity-colors": "^3.0.0",
         "@npmcli/installed-package-contents": "^2.0.2",
         "binary-extensions": "^2.2.0",
         "diff": "^5.1.0",
-        "minimatch": "^7.4.2",
+        "minimatch": "^9.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8",
         "tar": "^6.1.13"
@@ -12136,13 +12331,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "5.0.15",
+      "version": "6.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.7",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/run-script": "^6.0.0",
-        "chalk": "^4.1.0",
         "ci-info": "^3.7.1",
         "npm-package-arg": "^10.1.0",
         "npmlog": "^7.0.1",
@@ -12151,18 +12345,18 @@
         "read": "^2.0.0",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "4.0.15",
+      "version": "4.0.19",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.7"
+        "@npmcli/arborist": "^6.3.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -12181,7 +12375,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12193,11 +12387,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "5.0.15",
+      "version": "5.0.19",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.7",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/run-script": "^6.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8"
@@ -12207,7 +12401,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "7.1.3",
+      "version": "7.5.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12217,7 +12411,7 @@
         "npm-registry-fetch": "^14.0.3",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^1.0.0",
+        "sigstore": "^1.4.0",
         "ssri": "^10.0.1"
       },
       "engines": {
@@ -12271,7 +12465,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "11.0.3",
+      "version": "11.1.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12282,7 +12476,7 @@
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^7.7.1",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
@@ -12296,21 +12490,21 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "7.4.3",
+      "version": "9.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "4.2.5",
+      "version": "5.0.0",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -12340,11 +12534,11 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
       },
@@ -12497,14 +12691,15 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
+        "make-fetch-happen": "^11.0.3",
         "nopt": "^6.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
@@ -12517,18 +12712,6 @@
       },
       "engines": {
         "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
@@ -12555,82 +12738,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-      "version": "16.1.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
-      "version": "8.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
@@ -12670,32 +12777,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
       "inBundle": true,
@@ -12705,33 +12786,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -12775,38 +12829,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-      "version": "9.0.1",
+    "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+      "version": "3.0.7",
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
@@ -12823,7 +12849,7 @@
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.1.0",
+      "version": "7.2.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12851,12 +12877,9 @@
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -12873,7 +12896,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "6.1.0",
+      "version": "6.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12884,7 +12907,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -12943,12 +12966,12 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "14.0.3",
+      "version": "14.0.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "make-fetch-happen": "^11.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
@@ -13004,7 +13027,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "15.1.1",
+      "version": "15.2.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13014,7 +13037,7 @@
         "@npmcli/run-script": "^6.0.0",
         "cacache": "^17.0.0",
         "fs-minipass": "^3.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "npm-package-arg": "^10.0.0",
         "npm-packlist": "^7.0.0",
         "npm-pick-manifest": "^8.0.0",
@@ -13023,7 +13046,7 @@
         "promise-retry": "^2.0.1",
         "read-package-json": "^6.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^1.0.0",
+        "sigstore": "^1.3.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
@@ -13055,13 +13078,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm/node_modules/path-key": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.6.3",
+      "version": "1.9.2",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^7.14.1",
-        "minipass": "^4.0.2"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -13070,8 +13101,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
+      "version": "6.0.13",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13150,7 +13189,7 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13169,11 +13208,11 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "6.0.1",
+      "version": "6.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^9.3.0",
+        "glob": "^10.2.2",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^5.0.0",
         "npm-normalize-package-bin": "^3.0.0"
@@ -13195,7 +13234,7 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13270,7 +13309,21 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -13281,7 +13334,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13310,19 +13363,44 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "2.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "1.2.0",
+      "version": "1.7.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
-        "make-fetch-happen": "^11.0.1",
-        "tuf-js": "^1.0.0"
+        "@sigstore/tuf": "^1.0.1",
+        "make-fetch-happen": "^11.0.1"
       },
       "bin": {
         "sigstore": "bin/sigstore.js"
@@ -13395,25 +13473,39 @@
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.2",
+      "version": "10.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^4.0.0"
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.1.1",
+      "version": "1.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
@@ -13437,25 +13529,37 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
+    "node_modules/npm/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "9.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.13",
+      "version": "6.1.15",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -13505,12 +13609,13 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "1.1.2",
+      "version": "1.1.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "1.0.1",
-        "make-fetch-happen": "^11.0.1"
+        "@tufjs/models": "1.0.4",
+        "debug": "^4.3.4",
+        "make-fetch-happen": "^11.1.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13564,7 +13669,7 @@
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC"
     },
@@ -13577,7 +13682,7 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -13598,18 +13703,108 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13739,9 +13934,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-      "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.0.0",
@@ -13774,15 +13969,30 @@
       }
     },
     "node_modules/ora/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/is-unicode-supported": {
@@ -13813,10 +14023,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -13930,37 +14156,35 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-6.0.4.tgz",
+      "integrity": "sha512-FbJYeusBOZNe6bmrC2/+r/HljwExryon16lNKEU82gWiwIPMCEktUPSEAcTkO9K3jd/YPGuX/azZel1ltmo6nQ==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "pac-resolver": "^6.0.1",
+        "socks-proxy-agent": "^8.0.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
       }
     },
     "node_modules/pac-resolver": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.1.tgz",
-      "integrity": "sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-6.0.2.tgz",
+      "integrity": "sha512-EQpuJ2ifOjpZY5sg1Q1ZeAxvtLwR7Mj3RgY8cysPGbsRu3RBXyJFWxnMus9PScjxya/0LzvVDxNh/gl0eXBU4w==",
       "dev": true,
       "dependencies": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
+        "degenerator": "^4.0.4",
+        "ip": "^1.1.8",
         "netmask": "^2.0.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
       }
     },
     "node_modules/package-json": {
@@ -13994,9 +14218,9 @@
       }
     },
     "node_modules/package-json/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -14350,22 +14574,31 @@
       "dev": true
     },
     "node_modules/proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-OIbBKlRAT+ycCm6wAYIzMwPejzRtjy8F3QiDX0eKOA3e4pe3U9F/IvzcHP42bmgQxVv97juG+J8/gx+JIeCX/Q==",
       "dev": true,
       "dependencies": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^6.0.3",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/proxy-from-env": {
@@ -14478,21 +14711,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -14537,22 +14755,18 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -14698,21 +14912,21 @@
       }
     },
     "node_modules/release-it": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-15.10.1.tgz",
-      "integrity": "sha512-Wkk4aFHSo27vQwHIlcEy77lJwnQlh4UDQckc53gh5tKo7F22mAUEAe8SYQZJcFh7icdkf0OV70onhB1dDmeClA==",
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-15.11.0.tgz",
+      "integrity": "sha512-lZwoGEnKYKwGnfxxlA7vtR7vvozPrOSsIgQaHO4bgQ5ARbG3IA6Dmo0IVusv6nR1KmnjH70QIeNAgsWs6Ji/tw==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
-        "@octokit/rest": "19.0.7",
+        "@octokit/rest": "19.0.11",
         "async-retry": "1.3.3",
         "chalk": "5.2.0",
         "cosmiconfig": "8.1.3",
         "execa": "7.1.1",
         "git-url-parse": "13.1.0",
-        "globby": "13.1.3",
-        "got": "12.6.0",
-        "inquirer": "9.1.5",
+        "globby": "13.1.4",
+        "got": "12.6.1",
+        "inquirer": "9.2.6",
         "is-ci": "3.0.1",
         "issue-parser": "6.0.0",
         "lodash": "4.17.21",
@@ -14720,11 +14934,11 @@
         "new-github-release-url": "2.0.0",
         "node-fetch": "3.3.1",
         "open": "9.1.0",
-        "ora": "6.3.0",
+        "ora": "6.3.1",
         "os-name": "5.1.0",
         "promise.allsettled": "1.0.6",
-        "proxy-agent": "5.0.0",
-        "semver": "7.3.8",
+        "proxy-agent": "6.2.1",
+        "semver": "7.5.1",
         "shelljs": "0.8.5",
         "update-notifier": "6.0.2",
         "url-join": "5.0.0",
@@ -14798,9 +15012,9 @@
       }
     },
     "node_modules/release-it/node_modules/globby": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
@@ -14916,9 +15130,9 @@
       }
     },
     "node_modules/release-it/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -15081,19 +15295,16 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/retry": {
@@ -15144,9 +15355,9 @@
       }
     },
     "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
@@ -15175,9 +15386,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -15280,9 +15491,9 @@
       }
     },
     "node_modules/semver-diff/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -15312,12 +15523,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -15462,17 +15667,17 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
+      "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
       "dev": true,
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "agent-base": "^7.0.1",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/socks/node_modules/ip": {
@@ -15546,15 +15751,6 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
-    "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -15583,10 +15779,13 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -15821,9 +16020,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-2.6.2.tgz",
-      "integrity": "sha512-BVlrx6bjVMMIG4JBle0AO9t6dER51+t7ncWGptbnJYzUE/FkigZTHLCPDj4uNid6WYg4yz4AzfkA408WvTiCQg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-3.0.1.tgz",
+      "integrity": "sha512-SI0RtmJ3wwnm/SRIondA4QGHdWDXFHlB4CpMNMs4z0nP4k5hc4Gj0iZd0m55Izhv9sO4ARqRSONDtq9l1HKuGA==",
       "dependencies": {
         "@babel/core": "^7.12.1",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
@@ -15842,7 +16041,6 @@
         "@babel/preset-react": "^7.12.1",
         "@babel/runtime": "^7.12.5",
         "@devexpress/bin-v8-flags-filter": "^1.3.0",
-        "@miherlosev/esm": "3.2.26",
         "@types/node": "^12.20.10",
         "async-exit-hook": "^1.1.2",
         "babel-plugin-module-resolver": "^5.0.0",
@@ -15852,7 +16050,7 @@
         "callsite-record": "^4.0.0",
         "chai": "4.3.4",
         "chalk": "^2.3.0",
-        "chrome-remote-interface": "^0.32.1",
+        "chrome-remote-interface": "^0.32.2",
         "coffeescript": "^2.3.1",
         "commander": "^8.3.0",
         "debug": "^4.3.1",
@@ -15902,12 +16100,12 @@
         "resolve-cwd": "^1.0.0",
         "resolve-from": "^4.0.0",
         "sanitize-filename": "^1.6.0",
-        "semver": "^5.6.0",
+        "semver": "^7.5.3",
         "set-cookie-parser": "^2.5.1",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.25",
-        "testcafe-hammerhead": "31.4.3",
+        "testcafe-browser-tools": "2.0.26",
+        "testcafe-hammerhead": "31.4.6",
         "testcafe-legacy-api": "5.1.6",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.2.0",
@@ -15939,9 +16137,9 @@
       }
     },
     "node_modules/testcafe-browser-tools": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.25.tgz",
-      "integrity": "sha512-LK/ZOJUwnpjdJl131qrBN0toCv2wZj2Elb8UPTU71n9Woq7kZtGine4P5XvvvO7mE8bjBfWJOBW9jRhHxyIWzQ==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.26.tgz",
+      "integrity": "sha512-nTKSJhBzn9BmnOs0xVzXMu8dN2Gu13Ca3x3SJr/zF6ZdKjXO82JlbHu55dt5MFoWjzAQmwlqBkSxPaYicsTgUw==",
       "dependencies": {
         "array-find": "^1.0.0",
         "debug": "^4.3.1",
@@ -16114,9 +16312,9 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "31.4.3",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.4.3.tgz",
-      "integrity": "sha512-Z8wubj/8t3T5udVyqf2Kqy9oZFE8zDIWnuItVIEscYQ8PB6eWCkjq3oSx9J0XzSdakFnsUYP1T/KVlNe5z306w==",
+      "version": "31.4.6",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.4.6.tgz",
+      "integrity": "sha512-rooVb0bmKu94R9WrjY2E0iF+YFNrr7Jfz9F0a665xpZyfCresIl9pVaeMduEhbnw1grRfQJgT1PC+2LRQRWDRA==",
       "dependencies": {
         "@electron/asar": "^3.2.3",
         "acorn-hammerhead": "0.6.2",
@@ -16141,7 +16339,8 @@
         "read-file-relative": "^1.2.0",
         "semver": "5.5.0",
         "tough-cookie": "4.0.0",
-        "tunnel-agent": "0.6.0"
+        "tunnel-agent": "0.6.0",
+        "ws": "^7.4.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -16456,6 +16655,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/testcafe/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/testcafe/node_modules/resolve-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
@@ -16484,11 +16694,17 @@
       }
     },
     "node_modules/testcafe/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/testcafe/node_modules/source-map-support": {
@@ -16533,6 +16749,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/testcafe/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -16600,15 +16821,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/tough-cookie": {
@@ -16700,9 +16912,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -16760,9 +16972,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -16948,15 +17160,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -17062,9 +17265,9 @@
       }
     },
     "node_modules/update-notifier/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -17147,6 +17350,7 @@
       "version": "3.9.19",
       "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
       "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
+      "deprecated": "The library contains critical security issues and should not be used for production! The maintenance of the project has been discontinued. Consider migrating your code to isolated-vm.",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -17160,9 +17364,9 @@
       }
     },
     "node_modules/vm2/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -17339,9 +17543,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -17471,15 +17675,6 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
-      }
-    },
-    "node_modules/xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "16.0.3",
     "mocha-junit-reporter": "^2.2.0",
     "sauce-testrunner-utils": "1.3.0",
-    "testcafe": "2.6.2",
+    "testcafe": "3.0.1",
     "testcafe-browser-provider-ios": "0.5.0",
     "testcafe-reporter-saucelabs": "2.0.0",
     "typescript": "^5.0.4",


### PR DESCRIPTION
Bump testcafe to `testcafe@3.0.1`.

Breaking changes should have no impact that much:
- Breaking support with Internet Explorer
- Communicate with Chromium-Based browser with CDP.

Correct some security issues with `npm audit fix`