### PR TITLE
feat: Support setting TestCafe reporters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@saucelabs/testcomposer": "^1.0.0",
         "@tsconfig/node18": "^1.0.1",
         "dotenv": "16.0.3",
+        "lodash": "^4.17.21",
         "mocha-junit-reporter": "^2.2.0",
         "sauce-testrunner-utils": "1.3.0",
         "testcafe": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./bin/testcafe",
   "main": "lib/console-wrapper.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/sauce-testcafe-config.js lib/",
     "test": "node lib/console-wrapper.js",
     "lint": "eslint tests/ src/**/*.ts",
     "unit-test": "jest --env node",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./bin/testcafe",
   "main": "lib/console-wrapper.js",
   "scripts": {
-    "build": "tsc && cp src/sauce-testcafe-config.js lib/",
+    "build": "tsc && cp src/sauce-testcafe-config.cjs lib/",
     "test": "node lib/console-wrapper.js",
     "lint": "eslint tests/ src/**/*.ts",
     "unit-test": "jest --env node",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./bin/testcafe",
   "main": "lib/console-wrapper.js",
   "scripts": {
-    "build": "tsc && cp src/sauce-testcafe-config.js lib/",
+    "build": "tsc && cp src/sauce-testcafe-config.cjs lib/",
     "test": "node lib/console-wrapper.js",
     "lint": "eslint tests/ src/**/*.ts",
     "unit-test": "jest --env node",
@@ -21,6 +21,7 @@
     "@saucelabs/testcomposer": "^1.0.0",
     "@tsconfig/node18": "^1.0.1",
     "dotenv": "16.0.3",
+    "lodash": "^4.17.21",
     "mocha-junit-reporter": "^2.2.0",
     "sauce-testrunner-utils": "1.3.0",
     "testcafe": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./bin/testcafe",
   "main": "lib/console-wrapper.js",
   "scripts": {
-    "build": "tsc && cp src/sauce-testcafe-config.cjs lib/",
+    "build": "tsc && cp src/sauce-testcafe-config.js lib/",
     "test": "node lib/console-wrapper.js",
     "lint": "eslint tests/ src/**/*.ts",
     "unit-test": "jest --env node",

--- a/src/sauce-testcafe-config.cjs
+++ b/src/sauce-testcafe-config.cjs
@@ -18,7 +18,7 @@ for (const file of configFiles) {
       }
       if (extname === '.js' || extname === '.cjs') {
         userConfig = require(file);
-        if (config.default) {
+        if (userConfig.default) {
           userConfig = userConfig.default;
         }
       }

--- a/src/sauce-testcafe-config.cjs
+++ b/src/sauce-testcafe-config.cjs
@@ -6,18 +6,17 @@ let userConfig = {};
 
 const configFiles = process.env.TESTCAFE_CFG_FILE ?
   [process.env.TESTCAFE_CFG_FILE] :
-  ['./testcaferc.json', '.testcaferc.js', '.testcaferc.cjs'];
-
+  ['.testcaferc.json', '.testcaferc.js', '.testcaferc.cjs'];
 
 for (const file of configFiles) {
   if (fs.existsSync(file)) {
     try {
       const extname = path.extname(file);
-      if (extname === 'json') {
+      if (extname === '.json') {
         const content = fs.readFileSync(file);
         userConfig = JSON.parse(content.toString());
       }
-      if (extname === 'js' || extname === 'cjs') {
+      if (extname === '.js' || extname === '.cjs') {
         const config = require(file);
         if (config.default) {
           userConfig = config.default;
@@ -63,4 +62,6 @@ function arrMerger (objValue, srcValue) {
   }
 }
 
-module.exports = _.mergeWith(userConfig, overrides, arrMerger);
+const config = _.mergeWith(userConfig, overrides, arrMerger);
+console.log('final config: ', config);
+module.exports = config;

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -1,6 +1,6 @@
-import path from 'path';
-import fs from 'fs';
-import _ from 'lodash';
+const path = require('path');
+const fs = require('fs');
+const _ = require('lodash');
 
 let userConfig = {};
 

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -62,6 +62,4 @@ function arrMerger (objValue, srcValue) {
   }
 }
 
-const config = _.mergeWith(userConfig, overrides, arrMerger);
-console.log('final config: ', config);
-module.exports = config;
+module.exports = _.mergeWith(userConfig, overrides, arrMerger);

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -1,0 +1,66 @@
+import path from 'path';
+import fs from 'fs';
+import _ from 'lodash';
+
+let userConfig = {};
+
+const configFiles = process.env.TESTCAFE_CFG_FILE ?
+  [process.env.TESTCAFE_CFG_FILE] :
+  ['./testcaferc.json', '.testcaferc.js', '.testcaferc.cjs'];
+
+
+for (const file of configFiles) {
+  if (fs.existsSync(file)) {
+    try {
+      const extname = path.extname(file);
+      if (extname === 'json') {
+        const content = fs.readFileSync(file);
+        userConfig = JSON.parse(content.toString());
+      }
+      if (extname === 'js' || extname === 'cjs') {
+        const config = require(file);
+        if (config.default) {
+          userConfig = config.default;
+        } else {
+          userConfig = config;
+        }
+      }
+      break;
+    } catch (e) {
+      console.error(`failed to read TestCafe config file(${file}), err: ${e}`);
+    }
+  }
+}
+
+const overrides = {
+  reporter: [
+    {
+      name: 'xunit',
+      output: path.join(process.env.ASSETS_PATH || '', 'report.xml'),
+    },
+    {
+      name: 'json',
+      output: path.join(process.env.ASSETS_PATH || '', 'report.json'),
+    },
+    {
+      name: 'saucelabs',
+    },
+    {
+      name: 'list',
+    }
+  ]
+};
+
+// Values that are arrays are merged at the very end (see arrMerger()), but primitives are not.
+// Allow the user to set a single reporter like so: `reporter: 'list'`.
+if (userConfig.reporter && !(userConfig.reporter instanceof Array)) {
+  overrides.reporter.push(userConfig.reporter);
+}
+
+function arrMerger (objValue, srcValue) {
+  if (_.isArray(objValue)) {
+    return objValue.concat(srcValue);
+  }
+}
+
+module.exports = _.mergeWith(userConfig, overrides, arrMerger);

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -17,11 +17,9 @@ for (const file of configFiles) {
         userConfig = JSON.parse(content.toString());
       }
       if (extname === '.js' || extname === '.cjs') {
-        const config = require(file);
+        userConfig = require(file);
         if (config.default) {
-          userConfig = config.default;
-        } else {
-          userConfig = config;
+          userConfig = userConfig.default;
         }
       }
       break;

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -35,11 +35,11 @@ const overrides = {
   reporter: [
     {
       name: 'xunit',
-      output: path.join(process.env.ASSETS_PATH || '', 'report.xml'),
+      output: path.join(process.env.ASSETS_PATH || '__assets__', 'report.xml'),
     },
     {
       name: 'json',
-      output: path.join(process.env.ASSETS_PATH || '', 'report.json'),
+      output: path.join(process.env.ASSETS_PATH || '__assets__', 'report.json'),
     },
     {
       name: 'saucelabs',

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -26,7 +26,7 @@ for (const file of configFiles) {
       }
       break;
     } catch (e) {
-      console.error(`failed to read TestCafe config file(${file}), err: ${e}`);
+      console.error(`failed to read TestCafe config file(${file}):`, e);
     }
   }
 }

--- a/src/sauce-testcafe-config.js
+++ b/src/sauce-testcafe-config.js
@@ -6,7 +6,7 @@ let userConfig = {};
 
 const configFiles = process.env.TESTCAFE_CFG_FILE ?
   [process.env.TESTCAFE_CFG_FILE] :
-  ['.testcaferc.json', '.testcaferc.js', '.testcaferc.cjs'];
+  ['./.testcaferc.json', './.testcaferc.js', './.testcaferc.cjs'];
 
 for (const file of configFiles) {
   if (fs.existsSync(file)) {

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -288,8 +288,11 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
   process.env.SAUCE_SUITE_NAME = suiteName;
   process.env.SAUCE_ARTIFACTS_DIRECTORY = cfg.assetsPath;
 
-  // Set the TestCafe config file path. We merge it with the user-defined config file.
+  // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
+  // configuration, which may be needed for future use.
   const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
+  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
+
   const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath, configFile);
   const { hasPassed } = await runTestCafe(tcCommandLine, cfg.projectPath);
   try {

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -178,12 +178,6 @@ export function buildCommandLine (suite: Suite|undefined, projectPath: string, a
       cli.push('--compiler-options', options);
     }
   }
-  if (suite.nativeAutomation) {
-    cli.push('--native-automation');
-  }
-  if (suite.esm) {
-    cli.push('--esm');
-  }
 
   // Record a video if it's not a VM or if SAUCE_VIDEO_RECORD is set
   const shouldRecordVideo = !suite.disableVideo;
@@ -290,8 +284,8 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
 
   // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
   // configuration, which may be needed for future use.
-  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.cjs');
-  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.cjs'), configFile);
+  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
+  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
 
   const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath, configFile);
   const { hasPassed } = await runTestCafe(tcCommandLine, cfg.projectPath);

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -23,7 +23,7 @@ async function prepareConfiguration (nodeBin: string, runCfgPath: string, suiteN
     runCfg.path = runCfgPath;
     const projectPath = path.join(path.dirname(runCfgPath), runCfg.projectPath || '.');
     const assetsPath = path.join(path.dirname(runCfgPath), '__assets__');
-    const suite: Partial<Suite|undefined> = getSuite(runCfg, suiteName);
+    const suite = getSuite(runCfg, suiteName);
     const metadata = runCfg?.sauce?.metadata || {};
     const saucectlVersion = process.env.SAUCE_SAUCECTL_VERSION;
 
@@ -290,8 +290,8 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
 
   // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
   // configuration, which may be needed for future use.
-  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
-  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
+  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.cjs');
+  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.cjs'), configFile);
 
   const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath, configFile);
   const { hasPassed } = await runTestCafe(tcCommandLine, cfg.projectPath);

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -284,8 +284,8 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
 
   // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
   // configuration, which will be loaded during TestCafe setup step.
-  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
-  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
+  const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.cjs');
+  fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.cjs'), configFile);
 
   const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath, configFile);
   const { hasPassed } = await runTestCafe(tcCommandLine, cfg.projectPath);

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -283,7 +283,7 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
   process.env.SAUCE_ARTIFACTS_DIRECTORY = cfg.assetsPath;
 
   // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
-  // configuration, which will be needed for future use.
+  // configuration, which will be loaded during TestCafe setup step.
   const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
   fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
 

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -62,7 +62,7 @@ export function buildCompilerOptions (compilerOptions: CompilerOptions) {
 }
 
 // Buid the command line to invoke TestCafe with all required parameters
-export function buildCommandLine (suite: Suite|undefined, projectPath: string, assetsPath: string) {
+export function buildCommandLine (suite: Suite|undefined, projectPath: string, assetsPath: string, configFile: string|undefined) {
   const cli: (string|number)[] = [];
   if (suite === undefined) {
     return cli;
@@ -90,6 +90,10 @@ export function buildCommandLine (suite: Suite|undefined, projectPath: string, a
     cli.push(...suite.src);
   } else {
     cli.push(suite.src);
+  }
+
+  if (configFile) {
+    cli.push('--config-file', configFile);
   }
 
   if (suite.tsConfigPath) {
@@ -287,7 +291,7 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
   process.env.SAUCE_SUITE_NAME = suiteName;
   process.env.SAUCE_ARTIFACTS_DIRECTORY = cfg.assetsPath;
 
-  const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath);
+  const tcCommandLine = buildCommandLine(cfg.suite as Suite, cfg.projectPath, cfg.assetsPath, cfg.runCfg.testcafe.configFile);
   const { hasPassed } = await runTestCafe(tcCommandLine, cfg.projectPath);
   try {
     generateJunitFile(cfg.assetsPath, suiteName, (cfg.suite as Suite).browserName, (cfg.suite as Suite).platformName || '');

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -229,7 +229,14 @@ export function buildCommandLine (suite: Suite|undefined, projectPath: string, a
   const xmlReportPath = path.join(assetsPath, 'report.xml');
   const jsonReportPath = path.join(assetsPath, 'report.json');
   const sauceReportPath = path.join(assetsPath, 'sauce-test-report.json');
-  cli.push('--reporter', `xunit:${xmlReportPath},json:${jsonReportPath},saucelabs,list`);
+  const reporters = [
+    `xunit:${xmlReportPath}`,
+    `json:${jsonReportPath}`,
+    'saucelabs',
+    'list',
+    ...(suite.reporters || []),
+  ];
+  cli.push('--reporter', reporters.join(','));
 
   // Configure reporters
   process.env.SAUCE_DISABLE_UPLOAD = 'true';

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -283,7 +283,7 @@ async function run (nodeBin: string, runCfgPath: string, suiteName: string) {
   process.env.SAUCE_ARTIFACTS_DIRECTORY = cfg.assetsPath;
 
   // Copy our runner's TestCafe configuration to __project__/ to preserve the customer's
-  // configuration, which may be needed for future use.
+  // configuration, which will be needed for future use.
   const configFile = path.join(cfg.projectPath, 'sauce-testcafe-config.js');
   fs.copyFileSync(path.join(__dirname, 'sauce-testcafe-config.js'), configFile);
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -93,6 +93,10 @@ export type TestCafeConfig = {
   path: string,
   projectPath?: string,
   suites: Suite[],
-  assetsPath: string;
+  assetsPath: string,
   suite: Suite,
+  testcafe: {
+    version: string,
+    configFile?: string,
+  }
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -85,6 +85,7 @@ export type Suite = {
   preExec?: string[],
   nativeAutomation?: boolean;
   esm?: boolean;
+  reporters?: string[];
 }
 
 export type TestCafeConfig = {

--- a/src/type.ts
+++ b/src/type.ts
@@ -85,7 +85,6 @@ export type Suite = {
   preExec?: string[],
   nativeAutomation?: boolean;
   esm?: boolean;
-  reporters?: string[];
 }
 
 export type TestCafeConfig = {

--- a/src/type.ts
+++ b/src/type.ts
@@ -83,8 +83,6 @@ export type Suite = {
   screenshots?: Screenshots,
   filter?: Filter,
   preExec?: string[],
-  nativeAutomation?: boolean;
-  esm?: boolean;
 }
 
 export type TestCafeConfig = {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,26 +5,27 @@
 tests=(devxpress-test=success sauceswag-ok=success sauceswag-fail=failure)
 
 for i in ${tests[@]}; do
-    key=$(echo ${i} | cut -d '=' -f 1)
-    result=$(echo ${i} | cut -d '=' -f 2)
+    suite=$(echo ${i} | cut -d '=' -f 1)
+    expected_result=$(echo ${i} | cut -d '=' -f 2)
     tmpfile=$(mktemp)
-    echo $key
-    target_folder="./tests/local/$key"
-    cp ./lib/sauce-testcafe-config.js $target_folder
+    echo $suite
 
-    echo "Running ${key}:"
-    pushd $target_folder > /dev/null
+    current_suite_folder="./tests/local/$suite"
+    cp ./lib/sauce-testcafe-config.js $current_suite_folder
+
+    echo "Running ${suite}:"
+    pushd $current_suite_folder > /dev/null
     node ../../../ -r ./sauce-runner.json -s "saucy test" > ${tmpfile} 2>&1
     RETURN_CODE=${?}
     popd > /dev/null
 
-    echo "Result: ${RETURN_CODE}"
-    if ([ "${result}" == "success" ] && [ "${RETURN_CODE}" -ne 0 ]) ||
-         ([ "${result}" == "failure" ] && [ "${RETURN_CODE}" -eq 0 ]);then
+    echo "expected_result: ${RETURN_CODE}"
+    if ([ "${expected_result}" == "success" ] && [ "${RETURN_CODE}" -ne 0 ]) ||
+         ([ "${expected_result}" == "failure" ] && [ "${RETURN_CODE}" -eq 0 ]);then
         cat ${tmpfile}
         rm -f ${tmpfile}
 
-        echo "TEST FAILURE: Result expected is ${result}, and exitCode is ${RETURN_CODE}"
+        echo "TEST FAILURE: expected_result expected is ${expected_result}, and exitCode is ${RETURN_CODE}"
         exit 1
     fi
     rm -f ${tmpfile}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -8,9 +8,12 @@ for i in ${tests[@]}; do
     key=$(echo ${i} | cut -d '=' -f 1)
     result=$(echo ${i} | cut -d '=' -f 2)
     tmpfile=$(mktemp)
+    echo $key
+    target_folder="./tests/local/$key"
+    cp ./lib/sauce-testcafe-config.js $target_folder
 
     echo "Running ${key}:"
-    pushd ./tests/local/${key}/ > /dev/null
+    pushd $target_folder > /dev/null
     node ../../../ -r ./sauce-runner.json -s "saucy test" > ${tmpfile} 2>&1
     RETURN_CODE=${?}
     popd > /dev/null

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# SAUCECTL=$(realpath ${SAUCE_CTL_BINARY})
 # suite=result
 tests=(devxpress-test=success sauceswag-ok=success sauceswag-fail=failure)
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,7 +9,7 @@ for i in ${tests[@]}; do
     tmpfile=$(mktemp)
 
     current_suite_folder="./tests/local/$suite"
-    cp ./lib/sauce-testcafe-config.js $current_suite_folder
+    cp ./lib/sauce-testcafe-config.cjs $current_suite_folder
 
     echo "Running ${suite}:"
     pushd $current_suite_folder > /dev/null

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,7 +7,6 @@ for i in ${tests[@]}; do
     suite=$(echo ${i} | cut -d '=' -f 1)
     expected_result=$(echo ${i} | cut -d '=' -f 2)
     tmpfile=$(mktemp)
-    echo $suite
 
     current_suite_folder="./tests/local/$suite"
     cp ./lib/sauce-testcafe-config.js $current_suite_folder
@@ -24,7 +23,7 @@ for i in ${tests[@]}; do
         cat ${tmpfile}
         rm -f ${tmpfile}
 
-        echo "TEST FAILURE: expected_result expected is ${expected_result}, and exitCode is ${RETURN_CODE}"
+        echo "TEST FAILURE: Result expected is ${expected_result}, and exitCode is ${RETURN_CODE}"
         exit 1
     fi
     rm -f ${tmpfile}

--- a/tests/unit/src/testcafe-runner.spec.ts
+++ b/tests/unit/src/testcafe-runner.spec.ts
@@ -31,11 +31,7 @@ describe('.buildCommandLine', function () {
       '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('most basic config with typescript options', function () {
@@ -59,11 +55,7 @@ describe('.buildCommandLine', function () {
       '--compiler-options', 'typescript.configPath=tsconfig.json;typescript.customCompilerModulePath=/compiler/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with filters', function () {
@@ -100,11 +92,7 @@ describe('.buildCommandLine', function () {
       '--fixture-grep', '.*fixture-name.*',
       '--test-meta', 'my-key=my-val,2nd-key=2nd-val',
       '--fixture-meta', 'my-key=my-val,2nd-key=2nd-val',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with screenshots', function () {
@@ -126,11 +114,7 @@ describe('.buildCommandLine', function () {
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--screenshots', 'takeOnFails=true,fullPage=true,path=/fake/assets/path,pathPattern=${FILE_INDEX} - ${FIXTURE} - ${TEST}.png,thumbnails=false',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with quarantineMode', function () {
@@ -152,11 +136,7 @@ describe('.buildCommandLine', function () {
       '--quarantine-mode', 'attemptLimit=10,successThreshold=3',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with different flags', function () {
@@ -201,11 +181,7 @@ describe('.buildCommandLine', function () {
       '--disable-screenshots',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with client scripts', function () {
@@ -226,11 +202,7 @@ describe('.buildCommandLine', function () {
       '--client-scripts', '/fake/project/path/script.js',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with tsConfigPath', function () {
@@ -249,11 +221,7 @@ describe('.buildCommandLine', function () {
       '--ts-config-path', 'tsconfig.json',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with no-array src', function () {
@@ -270,11 +238,7 @@ describe('.buildCommandLine', function () {
       '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   it('basic with browserArgs', function () {
@@ -292,11 +256,7 @@ describe('.buildCommandLine', function () {
       '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-      '--reporter',
-      'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
     ]);
-    expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-    expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
   });
 
   describe('with env + inside VM', function () {
@@ -324,11 +284,7 @@ describe('.buildCommandLine', function () {
         '--video', '/fake/assets/path',
         '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
         '--proxy', 'localhost:8080',
-        '--reporter',
-        'xunit:/fake/assets/path/report.xml,json:/fake/assets/path/report.json,saucelabs,list',
       ]);
-      expect(process.env.SAUCE_REPORT_JSON_PATH).toBe('/fake/assets/path/sauce-test-report.json');
-      expect(process.env.SAUCE_DISABLE_UPLOAD).toBe('true');
     });
   });
 });

--- a/tests/unit/src/testcafe-runner.spec.ts
+++ b/tests/unit/src/testcafe-runner.spec.ts
@@ -23,10 +23,12 @@ describe('.buildCommandLine', function () {
       src: ['**/*.test.js'],
       name: 'unit test'
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--reporter',
@@ -48,10 +50,12 @@ describe('.buildCommandLine', function () {
         },
       },
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--compiler-options', 'typescript.configPath=tsconfig.json;typescript.customCompilerModulePath=/compiler/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
@@ -82,10 +86,12 @@ describe('.buildCommandLine', function () {
         },
       }
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--test', 'fixed-test-name',
@@ -111,10 +117,12 @@ describe('.buildCommandLine', function () {
         takeOnFails: true,
       },
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--screenshots', 'takeOnFails=true,fullPage=true,path=/fake/assets/path,pathPattern=${FILE_INDEX} - ${FIXTURE} - ${TEST}.png,thumbnails=false',
@@ -135,10 +143,12 @@ describe('.buildCommandLine', function () {
         successThreshold: 3,
       },
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--quarantine-mode', 'attemptLimit=10,successThreshold=3',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
@@ -169,10 +179,12 @@ describe('.buildCommandLine', function () {
       disablePageCaching: true,
       disableScreenshots: true,
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--skip-js-errors',
       '--skip-uncaught-errors',
       '--selector-timeout', 1000,
@@ -205,10 +217,12 @@ describe('.buildCommandLine', function () {
         'script.js',
       ],
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--client-scripts', '/fake/project/path/script.js',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
@@ -226,10 +240,12 @@ describe('.buildCommandLine', function () {
       src: ['**/*.test.js'],
       tsConfigPath: 'tsconfig.json',
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--ts-config-path', 'tsconfig.json',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
@@ -246,10 +262,12 @@ describe('.buildCommandLine', function () {
       browserName: 'firefox',
       src: '**/*.test.js',
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--reporter',
@@ -266,10 +284,12 @@ describe('.buildCommandLine', function () {
       src: '**/*.test.js',
       browserArgs: ['--chrome-fake-param'],
     };
-    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+    const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
     expect(cli).toMatchObject([
       'firefox --chrome-fake-param',
       '**/*.test.js',
+      '--config-file',
+      '/fake/configFile/path',
       '--video', '/fake/assets/path',
       '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--reporter',
@@ -295,10 +315,12 @@ describe('.buildCommandLine', function () {
         browserName: 'firefox',
         src: '**/*.test.js',
       };
-      const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path');
+      const cli = buildCommandLine(suite, '/fake/project/path', '/fake/assets/path', '/fake/configFile/path');
       expect(cli).toMatchObject([
         'D:\\chrome99\\chrome.exe',
         '**/*.test.js',
+        '--config-file',
+        '/fake/configFile/path',
         '--video', '/fake/assets/path',
         '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
         '--proxy', 'localhost:8080',


### PR DESCRIPTION
Use default `.testcaferc.json` https://app.saucelabs.com/tests/c42d810b4ff34d348aaa84f8262ddc9a
Use default `.testcaferc.js` https://app.saucelabs.com/tests/b71517cfd3cc4a60b32e3ee44b186550
Use default `.testcaferc.cjs` https://app.saucelabs.com/tests/09cc73bc002a43b89d44351288201d94

Set `configFile` to `testcafe.config.js` https://app.saucelabs.com/tests/2f1aa5f0d75e4e03a0bf096d3738ca9b
Set `configFile` to `testcafe.config.cjs` https://app.saucelabs.com/tests/8d2328296e2d422f9f1a8f90cdd5d090


Artifacts:
```
find artifacts
artifacts
artifacts/Chrome_on_macOS
artifacts/Chrome_on_macOS/testcafe.html <- html report
artifacts/Chrome_on_macOS/report.json
artifacts/Chrome_on_macOS/log.json
artifacts/Chrome_on_macOS/console.log
artifacts/Chrome_on_macOS/sauce-test-report.json
artifacts/Chrome_on_macOS/video.mp4
artifacts/Chrome_on_macOS/config.yml
artifacts/Chrome_on_macOS/junit.xml
artifacts/Chrome_on_macOS/report.xml
artifacts/Chrome_on_macOS/flags.json
```
