### PR TITLE
fix: remove native video creation

### DIFF
--- a/src/sauce-testcafe-config.cjs
+++ b/src/sauce-testcafe-config.cjs
@@ -45,7 +45,7 @@ const overrides = {
     {
       name: 'list',
     }
-  ]
+  ],
 };
 
 // Values that are arrays are merged at the very end (see arrMerger()), but primitives are not.
@@ -60,4 +60,13 @@ function arrMerger (objValue, srcValue) {
   }
 }
 
-module.exports = _.mergeWith(userConfig, overrides, arrMerger);
+const mergedConfig = _.mergeWith(userConfig, overrides, arrMerger);
+
+// Remove video related options from the merged config.
+// We'll handle them separately, because `_.mergeWith()` can't merge fields
+// with `undefined` values.
+mergedConfig.videoPath = undefined;
+mergedConfig.videoOptions = undefined;
+mergedConfig.videoEncodingOptions = undefined;
+
+module.exports = mergedConfig;

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -179,15 +179,6 @@ export function buildCommandLine (suite: Suite|undefined, projectPath: string, a
     }
   }
 
-  // Record a video if it's not a VM or if SAUCE_VIDEO_RECORD is set
-  const shouldRecordVideo = !suite.disableVideo;
-  if (shouldRecordVideo) {
-    cli.push(
-      '--video', assetsPath,
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
-    );
-  }
-
   // Screenshots
   if (suite.screenshots) {
     // Set screenshot pattern as fixture name, test name and screenshot #

--- a/tests/unit/src/testcafe-runner.spec.ts
+++ b/tests/unit/src/testcafe-runner.spec.ts
@@ -29,8 +29,6 @@ describe('.buildCommandLine', function () {
       '**/*.test.js',
       '--config-file',
       '/fake/configFile/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -53,8 +51,6 @@ describe('.buildCommandLine', function () {
       '--config-file',
       '/fake/configFile/path',
       '--compiler-options', 'typescript.configPath=tsconfig.json;typescript.customCompilerModulePath=/compiler/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -84,8 +80,6 @@ describe('.buildCommandLine', function () {
       '**/*.test.js',
       '--config-file',
       '/fake/configFile/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--test', 'fixed-test-name',
       '--fixture', 'fixed-fixture-name',
       '--test-grep', '.*test-name.*',
@@ -111,8 +105,6 @@ describe('.buildCommandLine', function () {
       '**/*.test.js',
       '--config-file',
       '/fake/configFile/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
       '--screenshots', 'takeOnFails=true,fullPage=true,path=/fake/assets/path,pathPattern=${FILE_INDEX} - ${FIXTURE} - ${TEST}.png,thumbnails=false',
     ]);
   });
@@ -134,8 +126,6 @@ describe('.buildCommandLine', function () {
       '--config-file',
       '/fake/configFile/path',
       '--quarantine-mode', 'attemptLimit=10,successThreshold=3',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -179,8 +169,6 @@ describe('.buildCommandLine', function () {
       '--stop-on-first-fail',
       '--disable-page-caching',
       '--disable-screenshots',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -200,8 +188,6 @@ describe('.buildCommandLine', function () {
       '--config-file',
       '/fake/configFile/path',
       '--client-scripts', '/fake/project/path/script.js',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -219,8 +205,6 @@ describe('.buildCommandLine', function () {
       '--config-file',
       '/fake/configFile/path',
       '--ts-config-path', 'tsconfig.json',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -236,8 +220,6 @@ describe('.buildCommandLine', function () {
       '**/*.test.js',
       '--config-file',
       '/fake/configFile/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -254,8 +236,6 @@ describe('.buildCommandLine', function () {
       '**/*.test.js',
       '--config-file',
       '/fake/configFile/path',
-      '--video', '/fake/assets/path',
-      '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
     ]);
   });
 
@@ -281,8 +261,6 @@ describe('.buildCommandLine', function () {
         '**/*.test.js',
         '--config-file',
         '/fake/configFile/path',
-        '--video', '/fake/assets/path',
-        '--video-options', 'singleFile=true,failedOnly=false,pathPattern=video.mp4',
         '--proxy', 'localhost:8080',
       ]);
     });


### PR DESCRIPTION
This should have been removed in https://github.com/saucelabs/sauce-testcafe-runner/pull/178, as the video creation was only needed when running in saucectl's docker mode.