### PR TITLE
refactor: use modern day styling rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,20 +1,15 @@
 {
     "extends": [
-        "eslint-config-appium",
-        "plugin:testcafe/recommended"
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
     ],
-    "plugins": ["jest", "testcafe", "@typescript-eslint"],
+    "plugins": [
+        "jest",
+        "testcafe",
+        "@typescript-eslint"
+    ],
     "rules": {
-        "no-console": "off",
-        "promise/no-native": "off",
-        "promise/prefer-await-to-callbacks": "off",
-        "promise/prefer-await-to-then": "off",
-        "promise/catch-or-return": "off",
-        "space-before-function-paren": ["error", {
-            "anonymous": "never",
-            "named": "never",
-            "asyncArrow": "always"
-        }]
+        "@typescript-eslint/no-var-requires": "off"
     },
     "env": {
         "jest/globals": true

--- a/src/console-wrapper.ts
+++ b/src/console-wrapper.ts
@@ -44,11 +44,9 @@ async function testCafeRunner() {
 
 if (require.main === module) {
   testCafeRunner()
-      // eslint-disable-next-line promise/prefer-await-to-then
       .then(() => {
         process.exit(0);
       })
-      // eslint-disable-next-line promise/prefer-await-to-callbacks
       .catch((err) => {
         console.error(err);
         process.exit(err);

--- a/src/sauce-testreporter.ts
+++ b/src/sauce-testreporter.ts
@@ -14,13 +14,13 @@ const getPlatformName = (platform: string) => {
 export function generateJunitFile(assetsPath: string, suiteName: string, browserName: string, platform: string) {
   const opts = {compact: true, spaces: 4, textFn: (val: string) => val};
   const xmlData = fs.readFileSync(path.join(assetsPath, `report.xml`), 'utf8');
-  let result : any = convert.xml2js(xmlData, opts);
+  const result : any = convert.xml2js(xmlData, opts);
 
   if (!result.testsuite) {
     return;
   }
 
-  let testsuites = result.testsuite;
+  const testsuites = result.testsuite;
   testsuites._attributes = testsuites._attributes || {};
   testsuites._attributes.id = 0;
   testsuites._attributes.name = suiteName;
@@ -57,6 +57,6 @@ export function generateJunitFile(assetsPath: string, suiteName: string, browser
   delete result.testsuite;
 
   opts.textFn = utils.escapeXML;
-  let xmlResult = convert.js2xml(result, opts);
+  const xmlResult = convert.js2xml(result, opts);
   fs.writeFileSync(path.join(assetsPath, 'junit.xml'), xmlResult);
 }

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -289,11 +289,9 @@ if (require.main === module) {
   const { nodeBin, runCfgPath, suiteName} = getArgs();
 
   run(nodeBin, runCfgPath, suiteName)
-    // eslint-disable-next-line promise/prefer-await-to-then
     .then((passed) => {
       process.exit(passed ? 0 : 1);
     })
-    // eslint-disable-next-line promise/prefer-await-to-callbacks
     .catch((err) => {
       console.error(`Failed to setup or run TestCafe: ${err.message}`);
       process.exit(1);

--- a/tests/cloud/tests/no-sc/sauceswag.ok.test.js
+++ b/tests/cloud/tests/no-sc/sauceswag.ok.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Getting Started Sauce demo`
   .page `https://www.saucedemo.com/`;

--- a/tests/cloud/tests/sc/sauce-connect.test.js
+++ b/tests/cloud/tests/sc/sauce-connect.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Sauce-Connect`.page `http://localhost:8000/index.html`;
 

--- a/tests/local/devxpress-test/tests/devxpress.test.js
+++ b/tests/local/devxpress-test/tests/devxpress.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Getting Started`
   .page `http://devexpress.github.io/testcafe/example`;

--- a/tests/local/sauceswag-fail/tests/sauceswag.fail.test.js
+++ b/tests/local/sauceswag-fail/tests/sauceswag.fail.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Getting Started Sauce demo failing test`
   .page `https://www.saucedemo.com/`;

--- a/tests/local/sauceswag-ok/tests/sauceswag.ok.test.js
+++ b/tests/local/sauceswag-ok/tests/sauceswag.ok.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Getting Started Sauce demo`
   .page `https://www.saucedemo.com/`;

--- a/tests/post-release/tests/devxpress.test.js
+++ b/tests/post-release/tests/devxpress.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, fixture, test } from 'testcafe';
 
 fixture `Getting Started`
   .page `http://devexpress.github.io/testcafe/example`;


### PR DESCRIPTION
Fairly straightforward styling change based on the default recommended sets for js/ts.

Only exception added is `"@typescript-eslint/no-var-requires": "off"`, which permits us to dynamically `require()` [within a function](https://github.com/saucelabs/sauce-testcafe-runner/pull/204/files#diff-8e0a3d9568b76eedb32e35049fef92c62507a612b611fcfb29e87ac1855fbec9R286).