### PR TITLE
ci: restore release type hints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'Release'
+        description: 'Release type - major, minor or patch'
         required: false
         default: ''
       preReleaseFlavor:


### PR DESCRIPTION
## Description

Restore the release type hints that must have been [accidentally removed](https://github.com/saucelabs/sauce-testcafe-runner/pull/206).