### PR TITLE
chore: Improve JUnit generation

### DIFF
--- a/src/sauce-testreporter.ts
+++ b/src/sauce-testreporter.ts
@@ -19,7 +19,9 @@ export function generateJUnitFile(
 ) {
   const junitPath = path.join(assetsPath, `report.xml`);
   if (!fs.existsSync(junitPath)) {
-    console.warn(`JUnit file(${junitPath}) not found`);
+    console.warn(
+      `JUnit file generation skipped as the original JUnit file (${junitPath}) from TestCafe was not located.`,
+    );
     return;
   }
   const opts = { compact: true, spaces: 4, textFn: (val: string) => val };

--- a/src/sauce-testreporter.ts
+++ b/src/sauce-testreporter.ts
@@ -20,7 +20,7 @@ export function generateJUnitFile(
   const junitPath = path.join(assetsPath, `report.xml`);
   if (!fs.existsSync(junitPath)) {
     console.warn(
-      `JUnit file generation skipped as the original JUnit file (${junitPath}) from TestCafe was not located.`,
+      `JUnit file generation skipped: the original JUnit file (${junitPath}) from TestCafe was not located.`,
     );
     return;
   }
@@ -29,6 +29,7 @@ export function generateJUnitFile(
   const result: any = convert.xml2js(xmlData, opts);
 
   if (!result.testsuite) {
+    console.warn('JUnit file generation skipped: no test suites detected.');
     return;
   }
 

--- a/src/sauce-testreporter.ts
+++ b/src/sauce-testreporter.ts
@@ -11,14 +11,19 @@ const getPlatformName = (platform: string) => {
   return platform;
 };
 
-export function generateJunitFile(
+export function generateJUnitFile(
   assetsPath: string,
   suiteName: string,
   browserName: string,
   platform: string,
 ) {
+  const junitPath = path.join(assetsPath, `report.xml`);
+  if (!fs.existsSync(junitPath)) {
+    console.warn(`JUnit file(${junitPath}) not found`);
+    return;
+  }
   const opts = { compact: true, spaces: 4, textFn: (val: string) => val };
-  const xmlData = fs.readFileSync(path.join(assetsPath, `report.xml`), 'utf8');
+  const xmlData = fs.readFileSync(junitPath, 'utf8');
   const result: any = convert.xml2js(xmlData, opts);
 
   if (!result.testsuite) {

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -11,7 +11,7 @@ import {
 } from 'sauce-testrunner-utils';
 
 import { TestCafeConfig, Suite, CompilerOptions, second } from './type';
-import { generateJunitFile } from './sauce-testreporter';
+import { generateJUnitFile } from './sauce-testreporter';
 import { setupProxy, isProxyAvailable } from './network-proxy';
 
 async function prepareConfiguration(
@@ -368,14 +368,14 @@ async function run(nodeBin: string, runCfgPath: string, suiteName: string) {
   const passed = await runTestCafe(tcCommandLine, projectPath, timeout);
 
   try {
-    generateJunitFile(
+    generateJUnitFile(
       assetsPath,
       suiteName,
       suite.browserName,
       suite.platformName || '',
     );
-  } catch (err) {
-    console.error(`Failed to generate junit file: ${err}`);
+  } catch (e) {
+    console.warn('Skipping JUnit file generation:', e);
   }
 
   return passed;


### PR DESCRIPTION
# Enhancements to JUnit File Generation

## Description

* Uses `console.warn` to issue warnings when there are failures in merging JUnit files.
* Checks the existence of JUnit file before reading.