### PR TITLE
ci: Use macos-13 runner for bundling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,8 @@ jobs:
           gh release upload ${{ steps.prep.outputs.version }} testcafe-windows-amd64.zip
 
   release-macos-bundle:
-    runs-on: macos-latest
+    # macos-latest is arm only which is not supported by the setup-ffmpeg action
+    runs-on: macos-13
     needs: [create-release-draft]
     steps:
       - name: Find matching draft tag


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

The ffmpeg action only supports x64, but macos-latest is now arm based.