### PR TITLE
feat: enable use of global node context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dotenv": "16.4.5",
         "lodash": "4.17.21",
         "mocha-junit-reporter": "^2.2.1",
-        "sauce-testrunner-utils": "3.0.0",
+        "sauce-testrunner-utils": "3.1.0",
         "shelljs": "^0.8.5",
         "testcafe": "3.6.2",
         "testcafe-browser-provider-ios": "0.5.0",
@@ -14265,9 +14265,9 @@
       }
     },
     "node_modules/sauce-testrunner-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.0.0.tgz",
-      "integrity": "sha512-0W7UuxJ/kOHlDdvFNUnv/HMIp9N8jNHVELkTxwDMZuEXP7EvRSkskaEblmqwCgU/3UxpjgpRxuhxKEj+mbOArA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.1.0.tgz",
+      "integrity": "sha512-jaDK1XxIq8A3peFjxkR6kXkQrmsa7SeVw5h/+qcpFX2PUvuXNv06PabqXvhD3JAG1SAqC6t6DIb/3Djz3OmLDQ==",
       "dependencies": {
         "lodash": "^4.17.21",
         "npm": "^10.8.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "16.4.5",
     "lodash": "4.17.21",
     "mocha-junit-reporter": "^2.2.1",
-    "sauce-testrunner-utils": "3.0.0",
+    "sauce-testrunner-utils": "3.1.0",
     "shelljs": "^0.8.5",
     "testcafe": "3.6.2",
     "testcafe-browser-provider-ios": "0.5.0",

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -16,6 +16,7 @@ import {
 import { TestCafeConfig, Suite, CompilerOptions, second } from './type';
 import { generateJUnitFile } from './sauce-testreporter';
 import { setupProxy, isProxyAvailable } from './network-proxy';
+import { NodeContext } from 'sauce-testrunner-utils/lib/types';
 
 async function prepareConfiguration(
   nodeBin: string,
@@ -65,7 +66,11 @@ async function prepareConfiguration(
     'bin',
     'npm-cli.js',
   );
-  const nodeCtx = { nodePath: nodeBin, npmPath: npmBin };
+  const nodeCtx: NodeContext = {
+    nodePath: nodeBin,
+    npmPath: npmBin,
+    useGlobals: !!runCfg.nodeVersion,
+  };
 
   // Install NPM dependencies
   await prepareNpmEnv(runCfg, nodeCtx);

--- a/src/type.ts
+++ b/src/type.ts
@@ -104,6 +104,7 @@ export type TestCafeConfig = {
     version: string;
     configFile?: string;
   };
+  nodeVersion?: string;
   artifacts?: Artifacts;
 };
 


### PR DESCRIPTION
## Description

Allow the runner to determine the proper node context: bundled vs. globally installed.

The context affects how we interact with `npm`.