### PR TITLE
feat: explicit browser profile settings for firefox

### DIFF
--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -126,6 +126,13 @@ export function buildCommandLine(
     const browserArgs = suite.browserArgs.join(' ');
     testCafeBrowserName = testCafeBrowserName + ' ' + browserArgs;
   }
+
+  const browserProfile = process.env.SAUCE_FIREFOX_BROWSER_PROFILE;
+  if (browserProfile) {
+    const absolutePath = path.join(projectPath, browserProfile);
+    testCafeBrowserName = `${testCafeBrowserName} -profile ${absolutePath}`;
+  }
+
   cli.push(testCafeBrowserName);
 
   // Add all sources files/globs

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -130,6 +130,7 @@ export function buildCommandLine(
   const browserProfile = process.env.SAUCE_FIREFOX_BROWSER_PROFILE;
   if (browserProfile) {
     const absolutePath = path.join(projectPath, browserProfile);
+    console.log(`Using Firefox profile: ${absolutePath}`);
     testCafeBrowserName = `${testCafeBrowserName} -profile ${absolutePath}`;
   }
 


### PR DESCRIPTION
## Description

Allows the user to specify a browser profile (path) for Firefox by setting the environment variable `SAUCE_FIREFOX_BROWSER_PROFILE`.

Jobs:
- macOS: https://app.saucelabs.com/tests/701190f7d488413fb7f2e9f61221efd0
- Windows: https://app.saucelabs.com/tests/3ac497b67d5346c6acd4699b1aacd1a7