### PR TITLE
fix for int-331

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dotenv": "17.2.3",
         "lodash": "4.17.23",
         "mocha-junit-reporter": "^2.2.1",
-        "sauce-testrunner-utils": "3.3.1",
+        "sauce-testrunner-utils": "^3.4.1",
         "shelljs": "^0.10.0",
         "testcafe": "3.7.4",
         "testcafe-browser-provider-ios": "0.8.1",
@@ -14997,9 +14997,9 @@
       }
     },
     "node_modules/sauce-testrunner-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.3.1.tgz",
-      "integrity": "sha512-8ZW18z/TduKYjKhjDYsa1a1A6kpKZitz/NC4rsuV++PZTCwCn9rR7J9mD+1V9ko9r9FBDvktPO4MIE95/MsdkA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/sauce-testrunner-utils/-/sauce-testrunner-utils-3.4.1.tgz",
+      "integrity": "sha512-SxFnknJ1wWJ/gNCBsDYTA3H1DWOYnr01LXH5Qwny8n83tRaCpzNGctQtIGkSf+IugRh7cmzbyt0d9SO2GhDgQg==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "17.2.3",
     "lodash": "4.17.23",
     "mocha-junit-reporter": "^2.2.1",
-    "sauce-testrunner-utils": "3.3.1",
+    "sauce-testrunner-utils": "^3.4.0",
     "shelljs": "^0.10.0",
     "testcafe": "3.7.4",
     "testcafe-browser-provider-ios": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "17.2.3",
     "lodash": "4.17.23",
     "mocha-junit-reporter": "^2.2.1",
-    "sauce-testrunner-utils": "^3.4.0",
+    "sauce-testrunner-utils": "^3.4.1",
     "shelljs": "^0.10.0",
     "testcafe": "3.7.4",
     "testcafe-browser-provider-ios": "0.8.1",

--- a/src/testcafe-runner.ts
+++ b/src/testcafe-runner.ts
@@ -10,6 +10,7 @@ import {
   loadRunConfig,
   preExec,
   prepareNpmEnv,
+  runWithStdoutWatchdog,
   zip,
 } from 'sauce-testrunner-utils';
 
@@ -321,14 +322,25 @@ async function runTestCafe(
     'testcafe-with-v8-flag-filter.js',
   );
 
+  // stdio is piped (not inherited) so the no-progress watchdog can observe
+  // TestCafe's output. Chunks are still echoed to the parent's stdout/stderr
+  // by runWithStdoutWatchdog, preserving existing log behavior.
   const testcafeProc = spawn(
     nodeBin,
     [testcafeBin, ...(tcCommandLine as string[])],
     {
-      stdio: 'inherit',
+      stdio: ['inherit', 'pipe', 'pipe'],
       cwd: projectPath,
       env: process.env,
     },
+  );
+
+  const noProgressTimeoutSecs = Math.max(
+    1,
+    parseInt(
+      process.env.SAUCE_TESTCAFE_NO_PROGRESS_TIMEOUT_SECS ?? '180',
+      10,
+    ) || 180,
   );
 
   const timeoutPromise = new Promise<boolean>((resolve) => {
@@ -338,14 +350,18 @@ async function runTestCafe(
     }, timeout * 1000);
   });
 
-  const testcafePromise = new Promise<boolean>((resolve) => {
-    testcafeProc.on('close', (code /*, ...args*/) => {
-      resolve(code === 0);
-    });
+  const watchdogPromise = runWithStdoutWatchdog(testcafeProc, {
+    noProgressTimeoutSecs,
+    tag: 'Sauce TestCafe Runner',
+  }).then(({ exitCode, watchdogFired }) => {
+    if (watchdogFired) {
+      return false;
+    }
+    return exitCode === 0;
   });
 
   try {
-    return Promise.race([timeoutPromise, testcafePromise]);
+    return Promise.race([timeoutPromise, watchdogPromise]);
   } catch (e) {
     console.error(`Failed to run TestCafe: ${e}`);
   }


### PR DESCRIPTION
  **Summary**
Wires the new runWithStdoutWatchdog helper from sauce-testrunner-utils@3.4.0 into runTestCafe(). If TestCafe produces no output for SAUCE_TESTCAFE_NO_PROGRESS_TIMEOUT_SECS seconds (default 180s), the runner SIGTERMs the child
  and exits non-zero with a clear message. The existing 30-minute outer timeout is preserved as the hard ceiling.

  **Motivation**
Internal ticket INT-331: a customer's TestCafe build hangs silently when the test target returns an envoy 503 with an idle-but-open TCP socket. TestCafe waits indefinitely; the only thing that ends the job today is the 30-minute
outer kill.
Before fix: ~30 min silent spin. After fix: ~30s clean failure with Sauce TestCafe Runner: no output from child for 180s — terminating.
